### PR TITLE
fix: harden Bash read-only command analysis

### DIFF
--- a/docs/bash-read-only-security.md
+++ b/docs/bash-read-only-security.md
@@ -1,0 +1,45 @@
+# Bash read-only security model
+
+Easy Agent automatically approves a Bash command as read-only only when it can parse the complete command with its supported shell grammar and verify every command and argument against the read-only policy. Any unsupported or ambiguous syntax requires approval. In Plan Mode, the same result is denied instead of executed.
+
+## Supported shell grammar
+
+The analyzer accepts plain commands joined by `|`, `&&`, `||`, `;`, or newlines. On POSIX shells, single quotes, double quotes, and ordinary backslash escapes are recognized so control operators inside an argument are not mistaken for command boundaries. On Windows, the parser follows the narrower `cmd.exe` boundary: single quotes and `%`, `!`, or `^` expansion syntax require approval, while backslashes remain path characters.
+
+The following constructs are outside the automatically approved subset:
+
+- input and output redirection, including heredocs and here-strings;
+- command, parameter, process, pathname, and backtick expansion;
+- background execution, grouping, comments, and line continuation;
+- malformed quoting or control operators;
+- shell interpreters, inline scripts, and commands outside the allowlist.
+
+## Command policy
+
+The analyzer allows `ls`, `cat`, `grep`, `pwd`, `which`, `head`, `tail`, and `wc` after the shell grammar check succeeds. Commands with arguments that can write files or execute helpers receive additional validation:
+
+| Command | Automatically approved scope |
+| --- | --- |
+| `git` | `status`, `log`, `diff`, and `show`, excluding output and external helper options |
+| `find` | Queries that do not use deleting, executing, confirmation, or file-output actions |
+| `rg` | Searches that do not configure preprocessors or hostname executables |
+| `fd` | Searches that do not use per-result or batch execution |
+| `sed` | Display operations and substitutions without in-place output, file-loaded programs, write flags, or execution flags |
+
+Long-option abbreviations for unsafe options are treated as unsafe. If a new option cannot be classified confidently, it remains outside the automatic approval path.
+
+## Permission behavior
+
+Explicit Bash deny rules are evaluated before read-only approval in every permission mode. A command classified as read-only is automatically allowed in Default, Plan, and Auto modes. A command that is not classified as read-only follows the normal confirmation or Auto Mode classifier path; Plan Mode denies it.
+
+| Command | Classification |
+| --- | --- |
+| `git status --short` | Read-only |
+| `cat README.md | grep Easy` | Read-only |
+| `rg 'foo|bar' src` | Read-only |
+| `cat source > target` | Requires approval; denied in Plan Mode |
+| `find . -delete` | Requires approval; denied in Plan Mode |
+| `sed --in-place 's/a/b/' file` | Requires approval; denied in Plan Mode |
+| `cat $(touch target)` | Requires approval; denied in Plan Mode |
+
+Run `npm run test:bash-readonly` after changing the parser, command allowlist, validators, or permission routing. Add a regression case before extending the accepted grammar or command policy.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ Each offline test process receives a temporary `HOME`, `USERPROFILE`, XDG direct
 | Area | Included checks | Execution |
 | --- | --- | --- |
 | Core flow | CLI and Headless protocols, QueryEngine commands, provider stream adapters, tools, ToolSearch, MCP, Skills, tasks, and agents | `core` |
-| Permissions | Allow/deny behavior, Auto Mode configuration, Plan Mode paths, and sandbox policy | `core` |
+| Permissions | Allow/deny behavior, structured Bash read-only analysis, Auto Mode configuration, Plan Mode paths, and sandbox policy | `core` |
 | Storage and configuration | Configuration precedence and source shapes, session JSONL and restore shape, file history, and retention | `core`, `extensions` |
 | Extensions | Worktrees, agent teams, hooks, commands, web and multimodal tools, plugins, and resilience | `extensions` |
 | UI | Ink rendering, input, transcript, permission prompts, progress, status line, and plugin management | `ui` |
@@ -50,6 +50,12 @@ node --import tsx scripts/verify-production.ts --group core --list
 ```
 
 Multiple `--group` options may be combined. Tests in the default gate run sequentially with independent user directories so failures are reproducible and shared process state cannot leak between test files.
+
+Run the Bash read-only security regression suite directly while changing command parsing or permission behavior:
+
+```bash
+npm run test:bash-readonly
+```
 
 ## Platform and external checks
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:notices": "tsx src/scripts/test-useagentsession-notices.ts",
     "test:streaming": "tsx src/scripts/test-streaming.ts",
     "test:tools": "tsx src/scripts/test-tools.ts",
+    "test:bash-readonly": "node --import tsx src/scripts/test-bash-readonly.ts",
     "test:tasks": "tsx src/scripts/test-tasks.ts",
     "test:toolsearch": "node --import tsx src/scripts/test-toolsearch.ts && node --import tsx src/scripts/test-toolsearch-integration.ts",
     "test:toolsearch:live": "node --import tsx src/scripts/test-toolsearch-live.ts",

--- a/scripts/verify-production.ts
+++ b/scripts/verify-production.ts
@@ -27,6 +27,7 @@ const TESTS: TestDefinition[] = [
   { id: "provider-stream", group: "core", file: "src/scripts/test-providerstream-characterization.ts" },
   { id: "session-notices", group: "core", file: "src/scripts/test-useagentsession-notices.ts" },
   { id: "tools", group: "core", file: "src/scripts/test-tools.ts" },
+  { id: "bash-readonly", group: "core", file: "src/scripts/test-bash-readonly.ts" },
   { id: "tasks", group: "core", file: "src/scripts/test-tasks.ts" },
   { id: "tool-search", group: "core", file: "src/scripts/test-toolsearch.ts" },
   { id: "tool-search-integration", group: "core", file: "src/scripts/test-toolsearch-integration.ts" },

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -1,7 +1,10 @@
 import * as path from "node:path";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import type { Tool } from "../tools/Tool.js";
-import { isReadOnlyCommand } from "../tools/bashTool.js";
+import {
+  analyzeBashCommand,
+  type BashReadOnlyAnalysis,
+} from "../tools/bashReadOnlyAnalysis.js";
 import { getPlanFilePath } from "../context/plans.js";
 import { loadSettingSources, isTrustedScopeForSensitiveKeys } from "../config/sources.js";
 import {
@@ -424,13 +427,17 @@ export function buildPermissionRuleHint(toolName: string, input: Record<string, 
   return toolName;
 }
 
-function getRiskLabel(tool: Tool, input: Record<string, unknown>): string {
+function getRiskLabel(
+  tool: Tool,
+  input: Record<string, unknown>,
+  bashAnalysis?: BashReadOnlyAnalysis,
+): string {
   if (tool.name === "Bash") {
     const command = extractBashCommand(input);
     if (isDangerousBashCommand(command)) {
       return "High risk: destructive shell command detected";
     }
-    if (isReadOnlyCommand(command)) {
+    if (bashAnalysis?.isReadOnly) {
       return "Low risk: read-only shell command";
     }
     return "Medium risk: shell command may change files or git state";
@@ -469,6 +476,7 @@ async function resolveAutoModeDecision(
   request: PermissionRequest,
   settings: PermissionSettings,
   sessionRules: PermissionRuleSet,
+  bashAnalysis?: BashReadOnlyAnalysis,
 ): Promise<PermissionResponse> {
   if (isCoordinationTool(params.tool.name)) {
     return { behavior: "allow", reason: `${params.tool.name} writes coordination-only state`, request };
@@ -490,7 +498,7 @@ async function resolveAutoModeDecision(
     if (isHardDeniedBashCommand(command)) {
       return { behavior: "deny", reason: "high-risk shell command blocked in auto mode", request };
     }
-    if (isReadOnlyCommand(command)) {
+    if (bashAnalysis?.isReadOnly) {
       return { behavior: "allow", reason: "read-only shell command", request };
     }
   } else if (params.tool.isReadOnly()) {
@@ -591,11 +599,14 @@ export async function checkPermission(params: PermissionCheckParams): Promise<Pe
   const settings = params.settings ?? (await loadPermissionSettings(params.cwd));
   const mode = params.mode ?? settings.mode;
   const sessionRules = params.sessionRules ?? { allow: [], deny: [] };
+  const bashAnalysis = params.tool.name === "Bash"
+    ? analyzeBashCommand(extractBashCommand(params.input))
+    : undefined;
   const request: PermissionRequest = {
     toolName: params.tool.name,
     input: params.input,
     summary: summarizePermissionRequest(params.tool.name, params.input),
-    risk: getRiskLabel(params.tool, params.input),
+    risk: getRiskLabel(params.tool, params.input, bashAnalysis),
     ruleHint: buildPermissionRuleHint(params.tool.name, params.input),
   };
 
@@ -603,6 +614,16 @@ export async function checkPermission(params: PermissionCheckParams): Promise<Pe
   // fast-path. (Read-only status alone must NOT auto-allow arbitrary domains.)
   if (params.tool.name === "WebFetch") {
     return resolveWebFetchDecision(params, request, settings, sessionRules);
+  }
+
+  // Explicit Bash deny rules must win before every read-only fast path,
+  // including Plan Mode and Auto Mode.
+  if (
+    params.tool.name === "Bash" &&
+    (matchesAnyRule(sessionRules.deny, "Bash", params.input) ||
+      matchesAnyRule(settings.deny, "Bash", params.input))
+  ) {
+    return { behavior: "deny", reason: "matched deny rule", request };
   }
 
   // Auto Mode: replace the legacy "allow everything" short-circuit with a
@@ -614,7 +635,7 @@ export async function checkPermission(params: PermissionCheckParams): Promise<Pe
   // skip the classifier entirely and fall through to the default-mode
   // handling below — i.e. behave as manual confirmation — notifying once.
   if (mode === "auto" && !isAutoModeCircuitBroken()) {
-    return await resolveAutoModeDecision(params, request, settings, sessionRules);
+    return await resolveAutoModeDecision(params, request, settings, sessionRules, bashAnalysis);
   }
   if (mode === "auto") {
     notifyCircuitBreakOnce();
@@ -642,8 +663,7 @@ export async function checkPermission(params: PermissionCheckParams): Promise<Pe
       return { behavior: "ask", reason: "plan mode transition requires confirmation", request };
     }
     if (params.tool.name === "Bash") {
-      const command = extractBashCommand(params.input);
-      if (isReadOnlyCommand(command)) {
+      if (bashAnalysis?.isReadOnly) {
         return { behavior: "allow", reason: "read-only shell command allowed in plan mode", request };
       }
       return { behavior: "deny", reason: "plan mode blocks non-read-only Bash commands", request };
@@ -665,8 +685,7 @@ export async function checkPermission(params: PermissionCheckParams): Promise<Pe
   }
 
   if (params.tool.name === "Bash") {
-    const command = extractBashCommand(params.input);
-    if (isReadOnlyCommand(command)) {
+    if (bashAnalysis?.isReadOnly) {
       return { behavior: "allow", reason: "read-only shell command", request };
     }
   } else if (params.tool.isReadOnly()) {

--- a/src/scripts/test-bash-readonly.ts
+++ b/src/scripts/test-bash-readonly.ts
@@ -1,0 +1,233 @@
+#!/usr/bin/env tsx
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  checkPermission,
+  type PermissionMode,
+  type PermissionSettings,
+} from "../permissions/permissions.js";
+import {
+  recordClassifierFailure,
+  resetAutoModeState,
+} from "../permissions/autoModeState.js";
+import { analyzeBashCommand, isReadOnlyCommand } from "../tools/bashTool.js";
+import { findToolByName } from "../tools/index.js";
+
+const READ_ONLY_CASES = [
+  "pwd",
+  "git status",
+  "git status --short",
+  "git log --oneline -5",
+  "git diff --stat",
+  "git show HEAD:README.md",
+  "cat package.json",
+  "cat 'file with spaces.txt'",
+  "cat file\\ name",
+  "c''at README.md",
+  "cat foo\\;bar",
+  "grep -n 'foo;bar' README.md",
+  "grep \"a && b\" README.md",
+  "rg --line-number 'foo|bar' src",
+  "find src -type f -name '*.ts'",
+  "fd --type f package src",
+  "head -n 20 README.md",
+  "tail -n 20 README.md",
+  "wc -l README.md",
+  "sed -n '1,10p' README.md",
+  "sed 's/foo/bar/g' README.md",
+  "pwd && git status",
+  "cat README.md | grep Easy | head -n 2",
+  "pwd; git status",
+  "pwd\ngit status",
+  "cat '$HOME'",
+] as const;
+
+const REQUIRES_APPROVAL_CASES = [
+  "",
+  "cat source > target",
+  "cat source >> target",
+  "cat < source",
+  "cat source 2>&1",
+  "cat <<< data",
+  "cat <<EOF\ndata\nEOF",
+  "sed -i 's/a/b/' file",
+  "sed --in-place=.bak 's/a/b/' file",
+  "sed --in-pla=.bak 's/a/b/' file",
+  "sed -ni 's/a/b/' file",
+  "sed 's/a/b/w target' file",
+  "sed 'e touch target' file",
+  "sed -f commands.sed file",
+  "find . -delete",
+  "find . -dele",
+  "find . -exec rm {} +",
+  "find . -execdir sh -c 'touch target' ;",
+  "find . -ok rm {} +",
+  "find . -okdir rm {} +",
+  "find . -fprint target",
+  "fd pattern . --exec rm {}",
+  "fd pattern . -X rm",
+  "rg pattern . --pre 'touch target'",
+  "rg pattern . --hostname-bin 'touch target'",
+  "git diff --output=target",
+  "git diff --out=target",
+  "git show --ext-diff HEAD",
+  "git log --show-signature",
+  "git log --format='%G? %s'",
+  "git -c core.pager='touch target' log",
+  "cat $(touch target)",
+  "cat \"$(touch target)\"",
+  "cat `touch target`",
+  "cat <(touch target)",
+  "cat >(touch target)",
+  "cat ${FILE}",
+  "cat $FILE",
+  "cat *",
+  "cat file; touch target",
+  "cat file\ntouch target",
+  "cat file && touch target",
+  "cat file || touch target",
+  "cat file | tee target",
+  "cat file & touch target",
+  "cat file\\\ntouch target",
+  "cat file # comment",
+  "(cat file)",
+  "{ cat file; }",
+  "bash -c 'touch target'",
+  "eval 'touch target'",
+  "source script.sh",
+  "cat 'unterminated",
+  "cat trailing\\",
+  "pwd &&",
+  "| cat file",
+] as const;
+
+async function permissionFor(
+  mode: PermissionMode,
+  command: string,
+  cwd: string,
+  settingsOverrides: Partial<PermissionSettings> = {},
+) {
+  const tool = findToolByName("Bash");
+  assert.ok(tool, "Bash tool must be registered");
+  const settings: PermissionSettings = {
+    allow: settingsOverrides.allow ?? [],
+    deny: settingsOverrides.deny ?? [],
+    mode,
+  };
+  return checkPermission({ tool, input: { command }, cwd, mode, settings });
+}
+
+async function main(): Promise<void> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "easy-agent-bash-readonly-"));
+  const home = path.join(root, "home");
+  const cwd = path.join(root, "project");
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+
+  await mkdir(home, { recursive: true });
+  await mkdir(cwd, { recursive: true });
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+
+  try {
+    for (const command of READ_ONLY_CASES) {
+      assert.equal(
+        isReadOnlyCommand(command, { platform: "linux" }),
+        true,
+        `expected POSIX read-only: ${JSON.stringify(command)}`,
+      );
+    }
+    for (const command of REQUIRES_APPROVAL_CASES) {
+      assert.equal(
+        isReadOnlyCommand(command, { platform: "linux" }),
+        false,
+        `expected POSIX approval: ${JSON.stringify(command)}`,
+      );
+    }
+
+    const pipeline = analyzeBashCommand("cat README.md | grep Easy | head -n 2", { platform: "linux" });
+    assert.equal(pipeline.isReadOnly, true);
+    assert.equal(pipeline.reason, "read_only");
+    assert.deepEqual(
+      pipeline.commands.map((command) => command.name),
+      ["cat", "grep", "head"],
+    );
+
+    const redirection = analyzeBashCommand("cat source > target", { platform: "linux" });
+    assert.equal(redirection.reason, "unsupported_syntax");
+    assert.match(redirection.detail, /redirection/);
+
+    const unsafeArguments = analyzeBashCommand("sed -i 's/a/b/' file", { platform: "linux" });
+    assert.equal(unsafeArguments.reason, "unsafe_arguments");
+    assert.match(unsafeArguments.detail, /writes files/);
+
+    const unsupportedCommand = analyzeBashCommand("cat file; touch target", { platform: "linux" });
+    assert.equal(unsupportedCommand.reason, "unsupported_command");
+    assert.deepEqual(
+      unsupportedCommand.commands.map((command) => command.name),
+      ["cat", "touch"],
+    );
+
+    const WINDOWS_SHELL_BYPASS_CASES = [
+      "cat '%EVIL%&touch target'",
+      "cat %EVIL%",
+      "cat !EVIL!",
+      "cat file^&touch target",
+      "cat foo\\&touch target",
+      'cat "file\\"&touch target"',
+    ] as const;
+    for (const command of WINDOWS_SHELL_BYPASS_CASES) {
+      assert.equal(
+        isReadOnlyCommand(command, { platform: "win32" }),
+        false,
+        `expected Windows shell approval: ${JSON.stringify(command)}`,
+      );
+    }
+    assert.equal(isReadOnlyCommand('cat "C:\\Program Files\\file.txt"', { platform: "win32" }), true);
+    assert.equal(isReadOnlyCommand("git status && pwd", { platform: "win32" }), true);
+
+    assert.equal((await permissionFor("default", "git status", cwd)).behavior, "allow");
+    assert.equal((await permissionFor("plan", "git status", cwd)).behavior, "allow");
+    assert.equal((await permissionFor("default", "cat source > target", cwd)).behavior, "ask");
+    assert.equal((await permissionFor("plan", "cat source > target", cwd)).behavior, "deny");
+    assert.equal((await permissionFor("plan", "find . -delete", cwd)).behavior, "deny");
+
+    resetAutoModeState();
+    recordClassifierFailure();
+    recordClassifierFailure();
+    recordClassifierFailure();
+    assert.equal((await permissionFor("auto", "sed -i 's/a/b/' file", cwd)).behavior, "ask");
+    resetAutoModeState();
+
+    assert.equal(
+      (
+        await permissionFor("default", "git status", cwd, {
+          deny: ["Bash(git status*)"],
+        })
+      ).behavior,
+      "deny",
+      "an explicit Bash deny rule must override read-only auto-allow",
+    );
+
+    process.stdout.write(
+      `[pass] Bash read-only analysis: ${READ_ONLY_CASES.length} allowed, ` +
+        `${REQUIRES_APPROVAL_CASES.length} require approval, ` +
+        `${WINDOWS_SHELL_BYPASS_CASES.length} Windows bypasses blocked, permission modes verified.\n`,
+    );
+  } finally {
+    resetAutoModeState();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/tools/bashReadOnlyAnalysis.ts
+++ b/src/tools/bashReadOnlyAnalysis.ts
@@ -1,0 +1,504 @@
+export type BashReadOnlyReason =
+  | "read_only"
+  | "empty"
+  | "invalid_syntax"
+  | "unsupported_syntax"
+  | "unsupported_command"
+  | "unsafe_arguments";
+
+export interface ParsedBashCommand {
+  name: string;
+  args: string[];
+}
+
+export interface BashReadOnlyAnalysis {
+  isReadOnly: boolean;
+  reason: BashReadOnlyReason;
+  detail: string;
+  commands: ParsedBashCommand[];
+}
+
+export interface BashReadOnlyAnalysisOptions {
+  platform?: NodeJS.Platform;
+}
+
+interface ParseSuccess {
+  ok: true;
+  commands: ParsedBashCommand[];
+}
+
+interface ParseFailure {
+  ok: false;
+  reason: "empty" | "invalid_syntax" | "unsupported_syntax";
+  detail: string;
+  commands: ParsedBashCommand[];
+}
+
+type ParseResult = ParseSuccess | ParseFailure;
+
+function parseFailure(
+  reason: ParseFailure["reason"],
+  detail: string,
+  commands: ParsedBashCommand[],
+): ParseFailure {
+  return { ok: false, reason, detail, commands };
+}
+
+/**
+ * Parse the shell subset eligible for automatic read-only approval.
+ *
+ * The accepted grammar contains plain commands joined by pipes, logical
+ * operators, semicolons, or newlines. Anything outside this subset fails
+ * closed and requires approval.
+ */
+function parseRestrictedCommandList(
+  input: string,
+  platform: NodeJS.Platform,
+): ParseResult {
+  const source = input.replace(/\r\n?/g, "\n");
+  const windowsShell = platform === "win32";
+  if (!source.trim()) return parseFailure("empty", "command is empty", []);
+
+  const commands: ParsedBashCommand[] = [];
+  let words: string[] = [];
+  let word = "";
+  let wordStarted = false;
+  let quote: "single" | "double" | null = null;
+  let requiredCommandAfterSeparator = false;
+
+  const flushWord = () => {
+    if (!wordStarted) return;
+    words.push(word);
+    word = "";
+    wordStarted = false;
+  };
+
+  const flushCommand = (): boolean => {
+    flushWord();
+    const [name, ...args] = words;
+    words = [];
+    if (!name) return false;
+    commands.push({ name, args });
+    return true;
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index]!;
+
+    if (quote === "single") {
+      if (char === "'") quote = null;
+      else word += char;
+      wordStarted = true;
+      continue;
+    }
+
+    if (quote === "double") {
+      if (char === '"') {
+        quote = null;
+        wordStarted = true;
+        continue;
+      }
+      if (char === "$" || char === "`" || (windowsShell && (char === "%" || char === "!" || char === "^"))) {
+        return parseFailure("unsupported_syntax", "shell expansion requires approval", commands);
+      }
+      if (char === "\\") {
+        const next = source[index + 1];
+        if (next === undefined) return parseFailure("invalid_syntax", "trailing escape", commands);
+        if (windowsShell) {
+          word += char;
+          wordStarted = true;
+          continue;
+        }
+        if (next === "\n") {
+          return parseFailure("unsupported_syntax", "line continuation requires approval", commands);
+        }
+        if (next === '"' || next === "$" || next === "`" || next === "\\") {
+          word += next;
+        } else {
+          word += `\\${next}`;
+        }
+        wordStarted = true;
+        index += 1;
+        continue;
+      }
+      word += char;
+      wordStarted = true;
+      continue;
+    }
+
+    if (char === "'" && windowsShell) {
+      return parseFailure("unsupported_syntax", "single quotes are not portable to the Windows shell", commands);
+    }
+    if (char === "'" || char === '"') {
+      quote = char === "'" ? "single" : "double";
+      wordStarted = true;
+      continue;
+    }
+
+    if (char === " " || char === "\t") {
+      flushWord();
+      continue;
+    }
+
+    if (char === "\\") {
+      if (windowsShell) {
+        word += char;
+        wordStarted = true;
+        continue;
+      }
+      const next = source[index + 1];
+      if (next === undefined) return parseFailure("invalid_syntax", "trailing escape", commands);
+      if (next === "\n") {
+        return parseFailure("unsupported_syntax", "line continuation requires approval", commands);
+      }
+      word += next;
+      wordStarted = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === "$" || char === "`" || (windowsShell && (char === "%" || char === "!" || char === "^"))) {
+      return parseFailure("unsupported_syntax", "shell expansion requires approval", commands);
+    }
+    if (char === ">" || char === "<") {
+      return parseFailure("unsupported_syntax", "shell redirection requires approval", commands);
+    }
+    if (char === "(" || char === ")" || char === "{" || char === "}") {
+      return parseFailure("unsupported_syntax", "shell grouping requires approval", commands);
+    }
+    if (char === "*" || char === "?" || char === "[") {
+      return parseFailure("unsupported_syntax", "unquoted pathname expansion requires approval", commands);
+    }
+    if (char === "#" && !wordStarted) {
+      return parseFailure("unsupported_syntax", "shell comments require approval", commands);
+    }
+
+    if (char === "&") {
+      if (source[index + 1] !== "&") {
+        return parseFailure("unsupported_syntax", "background execution requires approval", commands);
+      }
+      if (!flushCommand()) return parseFailure("invalid_syntax", "missing command before &&", commands);
+      requiredCommandAfterSeparator = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === "|") {
+      const operator = source[index + 1] === "|" ? "||" : "|";
+      if (!flushCommand()) {
+        return parseFailure("invalid_syntax", `missing command before ${operator}`, commands);
+      }
+      requiredCommandAfterSeparator = true;
+      if (operator === "||") index += 1;
+      continue;
+    }
+
+    if (char === ";" || char === "\n") {
+      const hasCommand = flushCommand();
+      if (!hasCommand) {
+        if (char === "\n" && commands.length > 0 && !requiredCommandAfterSeparator) continue;
+        return parseFailure(
+          "invalid_syntax",
+          `missing command before ${char === "\n" ? "newline" : ";"}`,
+          commands,
+        );
+      }
+      requiredCommandAfterSeparator = false;
+      continue;
+    }
+
+    if (char === "\0") return parseFailure("invalid_syntax", "NUL byte is not valid shell input", commands);
+
+    word += char;
+    wordStarted = true;
+    requiredCommandAfterSeparator = false;
+  }
+
+  if (quote !== null) return parseFailure("invalid_syntax", "unterminated quote", commands);
+  if (flushCommand()) requiredCommandAfterSeparator = false;
+  if (requiredCommandAfterSeparator) {
+    return parseFailure("invalid_syntax", "missing command after control operator", commands);
+  }
+  if (commands.length === 0) return parseFailure("empty", "command is empty", []);
+  return { ok: true, commands };
+}
+
+const SIMPLE_READ_ONLY_COMMANDS = new Set([
+  "ls",
+  "cat",
+  "grep",
+  "pwd",
+  "which",
+  "head",
+  "tail",
+  "wc",
+]);
+
+const READ_ONLY_GIT_SUBCOMMANDS = new Set(["status", "log", "diff", "show"]);
+const UNSAFE_GIT_OPTIONS = new Set([
+  "--ext-diff",
+  "--textconv",
+  "--output",
+  "--show-signature",
+]);
+const UNSAFE_FIND_ACTIONS = new Set([
+  "-delete",
+  "-exec",
+  "-execdir",
+  "-ok",
+  "-okdir",
+  "-fprint",
+  "-fprint0",
+  "-fls",
+  "-fprintf",
+]);
+const UNSAFE_RG_OPTIONS = new Set(["--pre", "--hostname-bin"]);
+const UNSAFE_FD_LONG_OPTIONS = new Set(["--exec", "--exec-batch"]);
+
+function matchesOption(arg: string, option: string): boolean {
+  return arg === option || arg.startsWith(`${option}=`);
+}
+
+function matchesLongOptionOrAbbreviation(arg: string, option: string): boolean {
+  const name = arg.split("=", 1)[0]!;
+  return name.startsWith("--") && name.length >= 3 && option.startsWith(name);
+}
+
+function validateGit(args: string[]): string | null {
+  const [subcommand, ...subcommandArgs] = args;
+  if (!subcommand || !READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) {
+    return `git subcommand ${subcommand ?? "<missing>"} is not read-only allowlisted`;
+  }
+  const unsafe = subcommandArgs.find((arg) =>
+    [...UNSAFE_GIT_OPTIONS].some(
+      (option) => matchesOption(arg, option) || matchesLongOptionOrAbbreviation(arg, option),
+    ) || arg.includes("%G"),
+  );
+  return unsafe ? `git option ${unsafe} can write files or execute external helpers` : null;
+}
+
+function validateFind(args: string[]): string | null {
+  const unsafe = args.find((arg) => {
+    const normalized = arg.toLowerCase();
+    return [...UNSAFE_FIND_ACTIONS].some(
+      (action) => normalized === action || (normalized.length >= 3 && action.startsWith(normalized)),
+    );
+  });
+  return unsafe ? `find action ${unsafe} is not read-only` : null;
+}
+
+function validateRipgrep(args: string[]): string | null {
+  const unsafe = args.find((arg) =>
+    [...UNSAFE_RG_OPTIONS].some((option) => matchesOption(arg, option)),
+  );
+  return unsafe ? `rg option ${unsafe} can execute an external command` : null;
+}
+
+function validateFd(args: string[]): string | null {
+  let optionsEnded = false;
+  for (const arg of args) {
+    if (arg === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (optionsEnded) continue;
+    if ([...UNSAFE_FD_LONG_OPTIONS].some((option) => matchesOption(arg, option))) {
+      return `fd option ${arg} can execute an external command`;
+    }
+    if (/^-[^-]*[xX]/.test(arg)) {
+      return `fd option ${arg} can execute an external command`;
+    }
+  }
+  return null;
+}
+
+function findUnescapedDelimiter(script: string, delimiter: string, start: number): number {
+  let escaped = false;
+  for (let index = start; index < script.length; index += 1) {
+    const char = script[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === delimiter) return index;
+  }
+  return -1;
+}
+
+function isSafeSedDisplayScript(script: string): boolean {
+  const operation = script.at(-1);
+  if (!operation || !"pPqQdDnlN=".includes(operation)) return false;
+  const address = script.slice(0, -1);
+  if (!address) return true;
+  const parts = address.split(",");
+  return (
+    parts.length <= 2 &&
+    parts.every((part) => part === "$" || /^[0-9]+$/.test(part))
+  );
+}
+
+function isSafeSedSubstitution(script: string): boolean {
+  if (!script.startsWith("s") || script.length < 4) return false;
+  const delimiter = script[1]!;
+  if (/[A-Za-z0-9\\\s]/.test(delimiter)) return false;
+  const patternEnd = findUnescapedDelimiter(script, delimiter, 2);
+  if (patternEnd < 0) return false;
+  const replacementEnd = findUnescapedDelimiter(script, delimiter, patternEnd + 1);
+  if (replacementEnd < 0) return false;
+  const flags = script.slice(replacementEnd + 1);
+  return [...flags].every((flag) => "gIp0123456789".includes(flag));
+}
+
+function isSafeSedScript(script: string): boolean {
+  if (!script || script.includes(";") || script.includes("\n") || script.includes("\r")) {
+    return false;
+  }
+  return isSafeSedDisplayScript(script) || isSafeSedSubstitution(script);
+}
+
+function validateSed(args: string[]): string | null {
+  const scripts: string[] = [];
+  let optionsEnded = false;
+  let hasExplicitExpression = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (!optionsEnded && arg === "--") {
+      optionsEnded = true;
+      continue;
+    }
+    if (
+      !optionsEnded &&
+      (arg === "-i" ||
+        arg.startsWith("-i") ||
+        matchesOption(arg, "--in-place") ||
+        matchesLongOptionOrAbbreviation(arg, "--in-place"))
+    ) {
+      return `sed option ${arg} writes files`;
+    }
+    if (
+      !optionsEnded &&
+      (arg === "-f" ||
+        arg.startsWith("-f") ||
+        matchesOption(arg, "--file") ||
+        matchesLongOptionOrAbbreviation(arg, "--file"))
+    ) {
+      return `sed option ${arg} loads an unverified program`;
+    }
+    if (!optionsEnded && (arg === "-e" || arg === "--expression")) {
+      const expression = args[index + 1];
+      if (expression === undefined) return `sed option ${arg} is missing its expression`;
+      scripts.push(expression);
+      hasExplicitExpression = true;
+      index += 1;
+      continue;
+    }
+    if (!optionsEnded && arg.startsWith("-e") && arg.length > 2) {
+      scripts.push(arg.slice(2));
+      hasExplicitExpression = true;
+      continue;
+    }
+    if (!optionsEnded && arg.startsWith("--expression=")) {
+      scripts.push(arg.slice("--expression=".length));
+      hasExplicitExpression = true;
+      continue;
+    }
+    if (!optionsEnded && /^-[nErsuz]+$/.test(arg)) continue;
+    if (
+      !optionsEnded &&
+      [
+        "--quiet",
+        "--silent",
+        "--regexp-extended",
+        "--separate",
+        "--unbuffered",
+        "--null-data",
+      ].includes(arg)
+    ) {
+      continue;
+    }
+    if (!optionsEnded && arg.startsWith("-")) {
+      return `sed option ${arg} is not read-only allowlisted`;
+    }
+    if (!hasExplicitExpression && scripts.length === 0) {
+      scripts.push(arg);
+    }
+  }
+
+  if (scripts.length === 0) return "sed program is missing";
+  const unsafeScript = scripts.find((script) => !isSafeSedScript(script));
+  if (unsafeScript !== undefined) return "sed program may write files or execute commands";
+  return null;
+}
+
+function validateCommand(command: ParsedBashCommand): { supported: boolean; detail: string | null } {
+  if (SIMPLE_READ_ONLY_COMMANDS.has(command.name)) {
+    return { supported: true, detail: null };
+  }
+
+  const validators: Record<string, (args: string[]) => string | null> = {
+    git: validateGit,
+    find: validateFind,
+    rg: validateRipgrep,
+    fd: validateFd,
+    sed: validateSed,
+  };
+  const validator = validators[command.name];
+  if (!validator) {
+    return { supported: false, detail: `command ${command.name} is not read-only allowlisted` };
+  }
+  return { supported: true, detail: validator(command.args) };
+}
+
+export function analyzeBashCommand(
+  command: string,
+  options: BashReadOnlyAnalysisOptions = {},
+): BashReadOnlyAnalysis {
+  const parsed = parseRestrictedCommandList(command, options.platform ?? process.platform);
+  if (!parsed.ok) {
+    return {
+      isReadOnly: false,
+      reason: parsed.reason,
+      detail: parsed.detail,
+      commands: parsed.commands,
+    };
+  }
+
+  for (const parsedCommand of parsed.commands) {
+    const validation = validateCommand(parsedCommand);
+    if (!validation.supported) {
+      return {
+        isReadOnly: false,
+        reason: "unsupported_command",
+        detail: validation.detail ?? "command is not read-only allowlisted",
+        commands: parsed.commands,
+      };
+    }
+    if (validation.detail) {
+      return {
+        isReadOnly: false,
+        reason: "unsafe_arguments",
+        detail: validation.detail,
+        commands: parsed.commands,
+      };
+    }
+  }
+
+  return {
+    isReadOnly: true,
+    reason: "read_only",
+    detail: "every command and argument is read-only allowlisted",
+    commands: parsed.commands,
+  };
+}
+
+export function isReadOnlyCommand(
+  command: string,
+  options?: BashReadOnlyAnalysisOptions,
+): boolean {
+  return analyzeBashCommand(command, options).isReadOnly;
+}

--- a/src/tools/bashTool.ts
+++ b/src/tools/bashTool.ts
@@ -14,6 +14,18 @@ import {
   startBashProgress,
 } from "../state/bashProgressStore.js";
 import { readMergedEnv } from "../utils/settings.js";
+import {
+  analyzeBashCommand,
+} from "./bashReadOnlyAnalysis.js";
+
+export {
+  analyzeBashCommand,
+  isReadOnlyCommand,
+  type BashReadOnlyAnalysis,
+  type BashReadOnlyAnalysisOptions,
+  type BashReadOnlyReason,
+  type ParsedBashCommand,
+} from "./bashReadOnlyAnalysis.js";
 
 interface BashInput {
   command: string;
@@ -38,10 +50,7 @@ async function buildProfileForCwd(
   cwd: string,
   settings: ResolvedSandboxSettings,
 ) {
-  // Dynamic import: bashTool ⇄ permissions form a static-import cycle
-  // (permissions wants `isReadOnlyCommand` from us). We break it here
-  // — this path only runs when sandboxing is on, so the extra import
-  // cost is negligible.
+  // Load permission settings only when a sandbox profile is required.
   const { loadPermissionSettings } = await import("../permissions/permissions.js");
   const permissionSettings = await loadPermissionSettings(cwd);
   return buildSandboxProfile({
@@ -53,48 +62,10 @@ async function buildProfileForCwd(
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_OUTPUT_CHARS = 30_000;
-const READ_ONLY_COMMANDS = new Set([
-  "ls",
-  "cat",
-  "grep",
-  "rg",
-  "find",
-  "fd",
-  "pwd",
-  "which",
-  "git status",
-  "git log",
-  "git diff",
-  "git show",
-  "head",
-  "tail",
-  "wc",
-  "sed",
-]);
 
 function truncateOutput(value: string): string {
   if (value.length <= MAX_OUTPUT_CHARS) return value;
   return `${value.slice(0, MAX_OUTPUT_CHARS)}\n...[truncated ${value.length - MAX_OUTPUT_CHARS} chars]`;
-}
-
-function splitCommandSegments(command: string): string[] {
-  return command
-    .split(/&&|\|\||\|/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-}
-
-export function isReadOnlyCommand(command: string): boolean {
-  const segments = splitCommandSegments(command);
-  if (segments.length === 0) return false;
-  return segments.every((segment) => {
-    const normalized = segment.replace(/\s+/g, " ").trim();
-    if (READ_ONLY_COMMANDS.has(normalized)) return true;
-    const firstTwo = normalized.split(" ").slice(0, 2).join(" ");
-    if (READ_ONLY_COMMANDS.has(firstTwo)) return true;
-    const first = normalized.split(" ")[0];
-    return READ_ONLY_COMMANDS.has(first);
-  });
 }
 
 export const bashTool: Tool = {
@@ -119,6 +90,7 @@ export const bashTool: Tool = {
     if (!input.command) {
       return { content: "Error: command is required", isError: true };
     }
+    const readOnlyAnalysis = analyzeBashCommand(input.command);
 
     const timeoutMs = typeof input.timeout === "number" ? input.timeout : DEFAULT_TIMEOUT_MS;
 
@@ -226,7 +198,7 @@ export const bashTool: Tool = {
 
         const output = [
           `Command: ${input.command}`,
-          `Read-only: ${isReadOnlyCommand(input.command)}`,
+          `Read-only: ${readOnlyAnalysis.isReadOnly}`,
           `Sandbox: ${willSandbox ? "enabled" : "disabled"}`,
           `Exit code: ${code ?? -1}`,
           stdout ? `\nSTDOUT:\n${truncateOutput(stdout)}` : "",


### PR DESCRIPTION
## 问题与结果

Bash 只读判断此前按命令前缀和少量连接符拆分，`cat source > target`、`sed -i`、`find -delete`、命令替换等输入可能绕过确认；引号中的管道也会被错误拆分。

本 PR 引入受限 Shell 语法分析。只有完整输入能够解析，并且每个命令及参数都通过只读策略时，才会自动放行。无法确认的语法统一按非只读处理：默认模式要求确认，Plan Mode 直接拒绝，Auto Mode 进入原有分类流程。

## 改动

- 新增结构化 Bash 只读分析器，识别命令边界、引号和转义，并拒绝重定向、展开、后台执行、分组、续行及不完整语法。
- 为 `git`、`find`、`rg`、`fd`、`sed` 增加会写文件或执行外部程序的参数检查，包括危险长参数缩写。
- 单独处理 Windows `cmd.exe` 的引号、变量展开和转义边界。
- 权限层每次请求只分析一次 Bash 输入，并让显式 deny 规则优先于所有只读快速放行路径。
- 新增安全模型文档和生产门禁回归测试。

## 验证

- 修改前运行新增回归脚本会失败，首先暴露引号内管道被错误拆分；原实现也会把重定向、`sed -i`、`find -delete` 和命令替换判为只读。
- `npm run test:bash-readonly`：26 个只读场景通过，56 个需审批场景通过，6 个 Windows 绕过场景被阻止。
- `npm run typecheck`：通过。
- `npm run build`：通过。
- `npm run verify:production`：49/49 通过。
- `npm run verify:production:platform`：2/2 通过。

手工检查 `pwd`、`git status`、`cat README.md` 均返回 `read_only`；重定向和命令替换返回 `unsupported_syntax`，`sed -i` 与 `find -delete` 返回 `unsafe_arguments`。

## 兼容性与风险

`isReadOnlyCommand(command)` 保持原有导出和布尔返回值，CLI、配置、会话与 Bash 工具结果格式不变。安全边界改为失败关闭后，一些使用变量展开、通配符或未纳入受限语法的只读命令会要求确认；这是预期的权限收紧，不影响命令在用户确认后的执行。

Closes #3
