### PR TITLE
fix: harden file paths and format Skill tool cards

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ Each offline test process receives a temporary `HOME`, `USERPROFILE`, XDG direct
 | Area | Included checks | Execution |
 | --- | --- | --- |
 | Core flow | CLI and Headless protocols, QueryEngine commands, provider stream adapters, tools, ToolSearch, MCP, Skills, tasks, and agents | `core` |
-| Permissions | Allow/deny behavior, structured Bash read-only analysis, Auto Mode configuration, Plan Mode paths, and sandbox policy | `core` |
+| Permissions | Allow/deny behavior, structured Bash read-only analysis, realpath and symbolic-link boundaries, Auto Mode configuration, Plan Mode paths, and sandbox policy | `core` |
 | Storage and configuration | Configuration precedence and source shapes, session JSONL and restore shape, file history, and retention | `core`, `extensions` |
 | Extensions | Worktrees, agent teams, hooks, commands, web and multimodal tools, plugins, and resilience | `extensions` |
 | UI | Ink rendering, input, transcript, permission prompts, progress, status line, and plugin management | `ui` |
@@ -55,6 +55,12 @@ Run the Bash read-only security regression suite directly while changing command
 
 ```bash
 npm run test:bash-readonly
+```
+
+Run the workspace path boundary suite after changing file tools, allowed roots, file history, or path handling:
+
+```bash
+npm run test:path-boundary
 ```
 
 ## Platform and external checks

--- a/docs/workspace-path-security.md
+++ b/docs/workspace-path-security.md
@@ -1,0 +1,28 @@
+# Workspace path security
+
+Easy Agent file tools operate within the current working directory, trusted `additionalDirectories`, and the dedicated plan directory. Ordinary file tools do not receive access to the complete `~/.easy-agent` state tree. Memory, sessions, credentials, plugins, teams, and file-history backups remain behind their dedicated runtime features.
+
+## Path validation
+
+Every file-tool path passes two containment checks:
+
+1. The lexical path must be inside a declared root. This rejects absolute and `..` traversal outside the configured boundary.
+2. The canonical path must remain inside the canonical form of that same root. This resolves file links, directory links, junctions, and link chains before an operation begins.
+
+Reads require the complete target to exist. Writes resolve the deepest existing ancestor, reject dangling links and link loops, and recheck the target after creating parent directories. A configured root may itself be a symbolic link; its canonical target becomes the allowed boundary.
+
+## Stable operations
+
+Regular-file reads and updates use an open file descriptor after canonical validation. On platforms that provide `O_NOFOLLOW`, the final path component cannot be replaced with a link during the open. The descriptor identity is compared with the current path before data is returned or changed.
+
+Directory listings and subprocess searches retain a validation lease for the duration of the operation. Their results are discarded if the path resolves outside its allowed root or its filesystem identity changes before completion. Windows uses junction-aware canonical paths and identity checks when directory descriptors are unavailable.
+
+Write, Edit, and MultiEdit write through the validated descriptor. File history applies the same boundary when creating backups, computing diffs, deleting files, and restoring snapshots. Paths restored from session data are validated again before they can affect the filesystem.
+
+## Allowed internal paths
+
+The plan directory is the only global Easy Agent directory exposed to ordinary file tools. This keeps Plan Mode compatible with its existing plan-file workflow without exposing user settings, session transcripts, memory, plugin data, or file-history backups.
+
+Use dedicated commands and tools to manage other internal state. Add external working directories through the trusted `additionalDirectories` setting rather than linking out of the workspace.
+
+Run `npm run test:path-boundary` after changing file tools, path resolution, allowed roots, or file-history restore behavior.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:bash-heartbeat": "tsx src/scripts/smoke-bash-heartbeat.tsx",
     "test:live-group": "tsx src/scripts/smoke-live-group.tsx",
     "test:tool-tags": "tsx src/scripts/smoke-tool-tags.tsx",
+    "test:tool-card-format": "node --import tsx src/scripts/test-tool-card-format.ts",
     "test:transcript-wheel": "tsx src/scripts/smoke-transcript-wheel.tsx",
     "test:stage24-statusline": "tsx src/scripts/smoke-statusline.tsx",
     "test:stage24-command": "tsx src/scripts/smoke-command.tsx",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:notices": "tsx src/scripts/test-useagentsession-notices.ts",
     "test:streaming": "tsx src/scripts/test-streaming.ts",
     "test:tools": "tsx src/scripts/test-tools.ts",
+    "test:path-boundary": "node --import tsx src/scripts/test-path-boundary.ts",
     "test:bash-readonly": "node --import tsx src/scripts/test-bash-readonly.ts",
     "test:tasks": "tsx src/scripts/test-tasks.ts",
     "test:toolsearch": "node --import tsx src/scripts/test-toolsearch.ts && node --import tsx src/scripts/test-toolsearch-integration.ts",

--- a/scripts/verify-production.ts
+++ b/scripts/verify-production.ts
@@ -27,6 +27,7 @@ const TESTS: TestDefinition[] = [
   { id: "provider-stream", group: "core", file: "src/scripts/test-providerstream-characterization.ts" },
   { id: "session-notices", group: "core", file: "src/scripts/test-useagentsession-notices.ts" },
   { id: "tools", group: "core", file: "src/scripts/test-tools.ts" },
+  { id: "path-boundary", group: "core", file: "src/scripts/test-path-boundary.ts" },
   { id: "bash-readonly", group: "core", file: "src/scripts/test-bash-readonly.ts" },
   { id: "tasks", group: "core", file: "src/scripts/test-tasks.ts" },
   { id: "tool-search", group: "core", file: "src/scripts/test-toolsearch.ts" },

--- a/scripts/verify-production.ts
+++ b/scripts/verify-production.ts
@@ -69,6 +69,7 @@ const TESTS: TestDefinition[] = [
   { id: "bash-heartbeat", group: "ui", file: "src/scripts/smoke-bash-heartbeat.tsx" },
   { id: "live-group", group: "ui", file: "src/scripts/smoke-live-group.tsx" },
   { id: "tool-tags", group: "ui", file: "src/scripts/smoke-tool-tags.tsx" },
+  { id: "tool-card-format", group: "ui", file: "src/scripts/test-tool-card-format.ts" },
   { id: "transcript-wheel", group: "ui", file: "src/scripts/smoke-transcript-wheel.tsx" },
   { id: "status-line", group: "ui", file: "src/scripts/smoke-statusline.tsx" },
   { id: "command", group: "ui", file: "src/scripts/smoke-command.tsx" },

--- a/src/context/systemPrompt.ts
+++ b/src/context/systemPrompt.ts
@@ -37,7 +37,7 @@ export interface BuildSystemPromptOptions {
 // Identity framing — always present, regardless of output style.
 const IDENTITY_SECTIONS = [
   "You are Easy Agent, a terminal-native local coding assistant running inside the user's workspace.",
-  "Treat the current working directory as the primary workspace boundary. The Easy Agent system directory at ~/.easy-agent is also available for memory and session storage; do not assume other outside paths are available.",
+  "Treat the current working directory and explicitly configured additional directories as the file-tool boundary. Easy Agent exposes its plans directory when a plan file is required; memory, sessions, and other internal state are managed through dedicated runtime features.",
 ];
 
 // Coding instructions — dropped when an output style sets

--- a/src/core/attachImages.ts
+++ b/src/core/attachImages.ts
@@ -9,8 +9,18 @@
  */
 
 import type { ContentBlock } from "../types/message.js";
-import { imageBufferAsBlock, isImagePath } from "../tools/imageUtils.js";
-import { readWorkspaceFile } from "../tools/pathUtils.js";
+import {
+  formatImageSizeError,
+  imageBufferAsBlock,
+  isImagePath,
+  MAX_IMAGE_BYTES,
+} from "../tools/imageUtils.js";
+import {
+  readWorkspaceFile,
+  resolveSafePath,
+  WorkspaceFileTooLargeError,
+  WorkspacePathError,
+} from "../tools/pathUtils.js";
 import { IMAGE_REF_RE, consumePastedImage } from "./pastedImages.js";
 
 export interface BuiltUserContent {
@@ -66,7 +76,7 @@ export async function buildUserMessageContent(
 
   for (const ref of candidates) {
     try {
-      const file = await readWorkspaceFile(ref, cwd);
+      const file = await readWorkspaceFile(ref, cwd, { maxFileBytes: MAX_IMAGE_BYTES });
       const img = imageBufferAsBlock(file.requestedPath, file.data);
       if (img.ok) {
         blocks.push(img.block);
@@ -75,7 +85,17 @@ export async function buildUserMessageContent(
         errors.push(`${ref}: ${img.error}`);
       }
     } catch (error: unknown) {
-      errors.push(`${ref}: ${error instanceof Error ? error.message : String(error)}`);
+      let message: string;
+      if (error instanceof WorkspaceFileTooLargeError) {
+        message = formatImageSizeError(error.actualBytes);
+      } else if (error instanceof WorkspacePathError) {
+        message = error.message;
+      } else if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+        message = `Image not found: ${resolveSafePath(ref, cwd)}`;
+      } else {
+        message = `Cannot read image: ${error instanceof Error ? error.message : String(error)}`;
+      }
+      errors.push(`${ref}: ${message}`);
     }
   }
 

--- a/src/core/attachImages.ts
+++ b/src/core/attachImages.ts
@@ -9,8 +9,8 @@
  */
 
 import type { ContentBlock } from "../types/message.js";
-import { isImagePath, readImageAsBlock } from "../tools/imageUtils.js";
-import { resolveWorkspacePath } from "../tools/pathUtils.js";
+import { imageBufferAsBlock, isImagePath } from "../tools/imageUtils.js";
+import { readWorkspaceFile } from "../tools/pathUtils.js";
 import { IMAGE_REF_RE, consumePastedImage } from "./pastedImages.js";
 
 export interface BuiltUserContent {
@@ -66,8 +66,8 @@ export async function buildUserMessageContent(
 
   for (const ref of candidates) {
     try {
-      const abs = resolveWorkspacePath(ref, cwd);
-      const img = await readImageAsBlock(abs);
+      const file = await readWorkspaceFile(ref, cwd);
+      const img = imageBufferAsBlock(file.requestedPath, file.data);
       if (img.ok) {
         blocks.push(img.block);
         attached.push({ ref, bytes: img.bytes, mediaType: img.mediaType });

--- a/src/scripts/test-path-boundary.ts
+++ b/src/scripts/test-path-boundary.ts
@@ -1,0 +1,375 @@
+#!/usr/bin/env tsx
+
+import assert from "node:assert/strict";
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  configureFileHistory,
+  fileHistoryMakeSnapshot,
+  fileHistoryRewind,
+  fileHistoryTrackEdit,
+  getFileHistoryState,
+  setFileHistoryState,
+} from "../session/fileHistory.js";
+import { getPlansRoot, getUserSettingsPath } from "../utils/paths.js";
+import { toolResultText, type Tool, type ToolContext } from "../tools/Tool.js";
+import { fileEditTool } from "../tools/fileEditTool.js";
+import { fileReadTool } from "../tools/fileReadTool.js";
+import { fileWriteTool } from "../tools/fileWriteTool.js";
+import { globTool } from "../tools/globTool.js";
+import { grepTool } from "../tools/grepTool.js";
+import { multiEditTool } from "../tools/multiEditTool.js";
+import {
+  setAdditionalAllowedRoots,
+  updateWorkspaceTextFile,
+  withValidatedWorkspacePath,
+} from "../tools/pathUtils.js";
+
+interface CheckFailure {
+  label: string;
+  detail?: string;
+}
+
+async function call(tool: Tool, input: Record<string, unknown>, cwd: string) {
+  const context: ToolContext = { cwd };
+  return tool.call(input, context);
+}
+
+async function createFileSymlink(target: string, linkPath: string): Promise<void> {
+  await fs.symlink(target, linkPath, "file");
+}
+
+async function createDirectorySymlink(target: string, linkPath: string): Promise<void> {
+  await fs.symlink(target, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
+async function main(): Promise<void> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "easy-agent-path-boundary-"));
+  const home = path.join(root, "home");
+  const workspace = path.join(root, "workspace");
+  const outside = path.join(root, "outside");
+  const additional = path.join(root, "additional");
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const failures: CheckFailure[] = [];
+
+  const check = (condition: boolean, label: string, detail?: string) => {
+    if (condition) {
+      process.stdout.write(`  ✓ ${label}\n`);
+    } else {
+      failures.push({ label, detail });
+      process.stdout.write(`  ✗ ${label}${detail ? ` — ${detail}` : ""}\n`);
+    }
+  };
+
+  await Promise.all([
+    fs.mkdir(home, { recursive: true }),
+    fs.mkdir(workspace, { recursive: true }),
+    fs.mkdir(outside, { recursive: true }),
+    fs.mkdir(additional, { recursive: true }),
+  ]);
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  setAdditionalAllowedRoots([]);
+
+  try {
+    const outsideFile = path.join(outside, "secret.txt");
+    const escapeFile = path.join(workspace, "escape.txt");
+    await fs.writeFile(outsideFile, "outside-secret\n", "utf8");
+    await createFileSymlink(outsideFile, escapeFile);
+
+    process.stdout.write("File tools reject links that escape an allowed root\n");
+    const readEscape = await call(fileReadTool, { file_path: escapeFile }, workspace);
+    check(readEscape.isError === true, "Read rejects an escaping file link", toolResultText(readEscape.content));
+
+    const writeEscape = await call(
+      fileWriteTool,
+      { file_path: escapeFile, content: "write-bypass\n" },
+      workspace,
+    );
+    check(writeEscape.isError === true, "Write rejects an escaping file link", toolResultText(writeEscape.content));
+    check(
+      (await fs.readFile(outsideFile, "utf8")) === "outside-secret\n",
+      "Write leaves the external target unchanged",
+    );
+    await fs.writeFile(outsideFile, "outside-secret\n", "utf8");
+
+    const editEscape = await call(
+      fileEditTool,
+      { file_path: escapeFile, old_string: "outside-secret", new_string: "edit-bypass" },
+      workspace,
+    );
+    check(editEscape.isError === true, "Edit rejects an escaping file link", toolResultText(editEscape.content));
+    check(
+      (await fs.readFile(outsideFile, "utf8")) === "outside-secret\n",
+      "Edit leaves the external target unchanged",
+    );
+    await fs.writeFile(outsideFile, "outside-secret\n", "utf8");
+
+    const multiEscape = await call(
+      multiEditTool,
+      {
+        file_path: escapeFile,
+        edits: [{ old_string: "outside-secret", new_string: "multi-bypass" }],
+      },
+      workspace,
+    );
+    check(multiEscape.isError === true, "MultiEdit rejects an escaping file link", toolResultText(multiEscape.content));
+    check(
+      (await fs.readFile(outsideFile, "utf8")) === "outside-secret\n",
+      "MultiEdit leaves the external target unchanged",
+    );
+    await fs.writeFile(outsideFile, "outside-secret\n", "utf8");
+
+    const outsideDir = path.join(outside, "directory");
+    const escapeDir = path.join(workspace, "escape-dir");
+    await fs.mkdir(outsideDir);
+    await fs.writeFile(path.join(outsideDir, "visible.txt"), "external listing\n", "utf8");
+    await createDirectorySymlink(outsideDir, escapeDir);
+
+    const readDirectoryEscape = await call(fileReadTool, { file_path: escapeDir }, workspace);
+    check(readDirectoryEscape.isError === true, "Read rejects an escaping directory link");
+    const grepDirectoryEscape = await call(
+      grepTool,
+      { path: escapeDir, pattern: "external" },
+      workspace,
+    );
+    check(grepDirectoryEscape.isError === true, "Grep rejects an escaping directory link");
+    const globDirectoryEscape = await call(
+      globTool,
+      { path: escapeDir, pattern: "**/*.txt" },
+      workspace,
+    );
+    check(globDirectoryEscape.isError === true, "Glob rejects an escaping directory link");
+
+    const danglingTarget = path.join(outside, "created-through-link.txt");
+    const danglingLink = path.join(workspace, "dangling.txt");
+    await createFileSymlink(danglingTarget, danglingLink);
+    const danglingWrite = await call(
+      fileWriteTool,
+      { file_path: danglingLink, content: "created outside\n" },
+      workspace,
+    );
+    check(danglingWrite.isError === true, "Write rejects a dangling link");
+    check(
+      await fs.access(danglingTarget).then(() => false, () => true),
+      "Dangling link does not create its external target",
+    );
+
+    const chainOne = path.join(workspace, "chain-one.txt");
+    const chainTwo = path.join(workspace, "chain-two.txt");
+    await createFileSymlink(outsideFile, chainTwo);
+    await createFileSymlink(chainTwo, chainOne);
+    check(
+      (await call(fileReadTool, { file_path: chainOne }, workspace)).isError === true,
+      "Read rejects a link chain that escapes",
+    );
+
+    const loopOne = path.join(workspace, "loop-one");
+    const loopTwo = path.join(workspace, "loop-two");
+    await createFileSymlink(loopTwo, loopOne);
+    await createFileSymlink(loopOne, loopTwo);
+    check(
+      (await call(fileReadTool, { file_path: loopOne }, workspace)).isError === true,
+      "Read rejects a symbolic-link loop",
+    );
+
+    process.stdout.write("Links that remain inside an allowed root keep working\n");
+    const internalFile = path.join(workspace, "internal.txt");
+    const internalLink = path.join(workspace, "internal-link.txt");
+    await fs.writeFile(internalFile, "internal\n", "utf8");
+    await createFileSymlink(internalFile, internalLink);
+    check(
+      (await call(fileReadTool, { file_path: internalLink }, workspace)).isError !== true,
+      "Read accepts an internal file link",
+    );
+    check(
+      (await call(
+        fileEditTool,
+        { file_path: internalLink, old_string: "internal", new_string: "updated" },
+        workspace,
+      )).isError !== true,
+      "Edit accepts an internal file link",
+    );
+    check((await fs.readFile(internalFile, "utf8")) === "updated\n", "Internal link updates its in-root target");
+
+    const internalDirectory = path.join(workspace, "internal-directory");
+    const internalDirectoryLink = path.join(workspace, "internal-directory-link");
+    await fs.mkdir(internalDirectory);
+    await fs.writeFile(path.join(internalDirectory, "entry.txt"), "entry\n", "utf8");
+    await createDirectorySymlink(internalDirectory, internalDirectoryLink);
+    check(
+      (await call(fileReadTool, { file_path: internalDirectoryLink }, workspace)).isError !== true,
+      "Read accepts an internal directory link",
+    );
+
+    const nestedFile = path.join(workspace, "new", "nested", "file.txt");
+    check(
+      (await call(fileWriteTool, { file_path: nestedFile, content: "created\n" }, workspace)).isError !== true,
+      "Write creates a nested file inside the workspace",
+    );
+    check((await fs.readFile(nestedFile, "utf8")) === "created\n", "Nested file contains the requested content");
+    check(
+      (await call(fileWriteTool, { file_path: nestedFile, content: "overwritten\n" }, workspace)).isError !== true,
+      "Write overwrites an existing regular file",
+    );
+    check((await fs.readFile(nestedFile, "utf8")) === "overwritten\n", "Overwrite replaces the complete file");
+
+    setAdditionalAllowedRoots([additional]);
+    const additionalFile = path.join(additional, "allowed.txt");
+    await fs.writeFile(additionalFile, "additional\n", "utf8");
+    check(
+      (await call(fileReadTool, { file_path: additionalFile }, workspace)).isError !== true,
+      "Read accepts a configured additional root",
+    );
+    const additionalAlias = path.join(root, "additional-alias");
+    await createDirectorySymlink(additional, additionalAlias);
+    setAdditionalAllowedRoots([additionalAlias]);
+    check(
+      (await call(fileReadTool, { file_path: path.join(additionalAlias, "allowed.txt") }, workspace)).isError !== true,
+      "A configured root may itself be a symbolic link",
+    );
+    setAdditionalAllowedRoots([additional]);
+    const additionalEscape = path.join(additional, "escape.txt");
+    await createFileSymlink(outsideFile, additionalEscape);
+    check(
+      (await call(fileReadTool, { file_path: additionalEscape }, workspace)).isError === true,
+      "Additional roots cannot escape through a link",
+    );
+    setAdditionalAllowedRoots([]);
+
+    process.stdout.write("Ordinary file tools expose only the required internal state\n");
+    const userSettings = getUserSettingsPath();
+    await fs.mkdir(path.dirname(userSettings), { recursive: true });
+    await fs.writeFile(userSettings, '{"env":{"TOKEN":"secret"}}\n', "utf8");
+    check(
+      (await call(fileReadTool, { file_path: userSettings }, workspace)).isError === true,
+      "Read cannot access user settings through the global state root",
+    );
+    const settingsWrite = await call(
+      fileWriteTool,
+      { file_path: userSettings, content: "replaced\n" },
+      workspace,
+    );
+    check(settingsWrite.isError === true, "Write cannot access user settings through the global state root");
+    check(
+      (await fs.readFile(userSettings, "utf8")) === '{"env":{"TOKEN":"secret"}}\n',
+      "Blocked settings write leaves the file unchanged",
+    );
+    const planFile = path.join(getPlansRoot(), "boundary-test.md");
+    check(
+      (await call(fileWriteTool, { file_path: planFile, content: "plan\n" }, workspace)).isError !== true,
+      "Write can access the dedicated plans root",
+    );
+    const planEscape = path.join(getPlansRoot(), "settings-link.json");
+    await createFileSymlink(userSettings, planEscape);
+    check(
+      (await call(fileReadTool, { file_path: planEscape }, workspace)).isError === true,
+      "The plans root cannot link to other global state",
+    );
+
+    if (process.platform !== "win32") {
+      process.stdout.write("Open file descriptors contain path replacement races\n");
+      const updateRaceFile = path.join(workspace, "update-race.txt");
+      const updateRaceOutside = path.join(outside, "update-race-target.txt");
+      await fs.writeFile(updateRaceFile, "inside-before-race\n", "utf8");
+      await fs.writeFile(updateRaceOutside, "outside-before-race\n", "utf8");
+      await updateWorkspaceTextFile(updateRaceFile, workspace, () => {
+        fsSync.unlinkSync(updateRaceFile);
+        fsSync.symlinkSync(updateRaceOutside, updateRaceFile);
+        return { content: "descriptor-only-update\n", value: undefined };
+      });
+      check(
+        (await fs.readFile(updateRaceOutside, "utf8")) === "outside-before-race\n",
+        "An edit writes only to the validated descriptor after path replacement",
+      );
+
+      const readRaceFile = path.join(workspace, "read-race.txt");
+      const readRaceOutside = path.join(outside, "read-race-target.txt");
+      await fs.writeFile(readRaceFile, "inside-read\n", "utf8");
+      await fs.writeFile(readRaceOutside, "outside-read\n", "utf8");
+      let readRaceRejected = false;
+      try {
+        await withValidatedWorkspacePath(readRaceFile, workspace, async (resolvedPath) => {
+          await fs.unlink(resolvedPath);
+          await createFileSymlink(readRaceOutside, resolvedPath);
+          return fs.readFile(resolvedPath, "utf8");
+        });
+      } catch {
+        readRaceRejected = true;
+      }
+      check(readRaceRejected, "A path-based read discards results when the target identity changes");
+    }
+
+    process.stdout.write("File history uses the same path boundary\n");
+    await configureFileHistory(workspace, "boundary-track");
+    await fileHistoryMakeSnapshot("track");
+    await fileHistoryTrackEdit(escapeFile, "track");
+    check(
+      !getFileHistoryState().trackedFiles.has("escape.txt"),
+      "File history does not back up an escaping link",
+    );
+
+    const raceFile = path.join(workspace, "race.txt");
+    const raceOutside = path.join(outside, "race-target.txt");
+    await fs.writeFile(raceFile, "original\n", "utf8");
+    await fs.writeFile(raceOutside, "outside-race\n", "utf8");
+    await configureFileHistory(workspace, "boundary-race");
+    await fileHistoryMakeSnapshot("race");
+    await fileHistoryTrackEdit(raceFile, "race");
+    await fs.writeFile(raceFile, "changed\n", "utf8");
+    await fs.unlink(raceFile);
+    await createFileSymlink(raceOutside, raceFile);
+    await fileHistoryRewind("race");
+    check(
+      (await fs.readFile(raceOutside, "utf8")) === "outside-race\n",
+      "Rewind does not follow a replacement link outside the workspace",
+    );
+
+    const historySource = path.join(workspace, "history-source.txt");
+    const maliciousTarget = path.join(outside, "malicious-restore.txt");
+    await fs.writeFile(historySource, "history-source\n", "utf8");
+    await fs.writeFile(maliciousTarget, "outside-history\n", "utf8");
+    await configureFileHistory(workspace, "boundary-restored-state");
+    await fileHistoryMakeSnapshot("restored-state");
+    await fileHistoryTrackEdit(historySource, "restored-state");
+    const sourceState = getFileHistoryState();
+    const sourceSnapshot = sourceState.snapshots[0]!;
+    const sourceBackup = sourceSnapshot.trackedFileBackups["history-source.txt"]!;
+    setFileHistoryState({
+      snapshots: [{
+        messageId: "malicious",
+        timestamp: new Date().toISOString(),
+        trackedFileBackups: { [maliciousTarget]: sourceBackup },
+      }],
+      trackedFiles: new Set([maliciousTarget]),
+      snapshotSequence: 1,
+    });
+    await fileHistoryRewind("malicious");
+    check(
+      (await fs.readFile(maliciousTarget, "utf8")) === "outside-history\n",
+      "Rewind ignores an out-of-root path restored from session state",
+    );
+
+    assert.equal(
+      failures.length,
+      0,
+      failures.map((failure) => `${failure.label}${failure.detail ? `: ${failure.detail}` : ""}`).join("\n"),
+    );
+    process.stdout.write("\n[pass] Workspace path boundary verified.\n");
+  } finally {
+    setAdditionalAllowedRoots([]);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/scripts/test-path-boundary.ts
+++ b/src/scripts/test-path-boundary.ts
@@ -75,6 +75,95 @@ async function main(): Promise<void> {
   setAdditionalAllowedRoots([]);
 
   try {
+    process.stdout.write("Normal file-tool behavior remains compatible\n");
+    const normalFile = path.join(workspace, "normal.txt");
+    await fs.writeFile(normalFile, "alpha\nbeta\n", "utf8");
+    const normalRead = await call(fileReadTool, { file_path: normalFile }, workspace);
+    check(
+      toolResultText(normalRead.content) === `${normalFile} (3 lines)\n1\talpha\n2\tbeta\n3\t`,
+      "Read keeps its line-numbered result format",
+      toolResultText(normalRead.content),
+    );
+    const partialRead = await call(
+      fileReadTool,
+      { file_path: normalFile, offset: 2, limit: 1 },
+      workspace,
+    );
+    check(
+      toolResultText(partialRead.content) === `${normalFile} (lines 2-2 of 3)\n2\tbeta`,
+      "Read keeps offset and limit semantics",
+      toolResultText(partialRead.content),
+    );
+
+    const normalNestedFile = path.join(workspace, "normal", "nested.txt");
+    const normalCreate = await call(
+      fileWriteTool,
+      { file_path: normalNestedFile, content: "created\n" },
+      workspace,
+    );
+    check(
+      toolResultText(normalCreate.content) === `Created file: ${normalNestedFile} (8 chars)`,
+      "Write keeps its create result format",
+      toolResultText(normalCreate.content),
+    );
+    const normalOverwrite = await call(
+      fileWriteTool,
+      { file_path: normalNestedFile, content: "updated\n" },
+      workspace,
+    );
+    check(
+      toolResultText(normalOverwrite.content) === `Updated file: ${normalNestedFile} (8 chars)` &&
+        (await fs.readFile(normalNestedFile, "utf8")) === "updated\n",
+      "Write keeps overwrite behavior and result format",
+      toolResultText(normalOverwrite.content),
+    );
+
+    const normalEdit = await call(
+      fileEditTool,
+      { file_path: normalFile, old_string: "alpha", new_string: "ALPHA" },
+      workspace,
+    );
+    check(
+      normalEdit.isError !== true &&
+        toolResultText(normalEdit.content).startsWith(`Updated file: ${normalFile}\n`) &&
+        (await fs.readFile(normalFile, "utf8")) === "ALPHA\nbeta\n",
+      "Edit keeps its replacement and result semantics",
+      toolResultText(normalEdit.content),
+    );
+    const beforeFailedMultiEdit = await fs.readFile(normalFile, "utf8");
+    const failedMultiEdit = await call(
+      multiEditTool,
+      {
+        file_path: normalFile,
+        edits: [
+          { old_string: "ALPHA", new_string: "first" },
+          { old_string: "missing", new_string: "second" },
+        ],
+      },
+      workspace,
+    );
+    check(
+      failedMultiEdit.isError === true &&
+        (await fs.readFile(normalFile, "utf8")) === beforeFailedMultiEdit,
+      "MultiEdit remains atomic when a later edit fails",
+      toolResultText(failedMultiEdit.content),
+    );
+
+    const normalGrep = await call(grepTool, { path: workspace, pattern: "ALPHA" }, workspace);
+    check(
+      normalGrep.isError !== true && toolResultText(normalGrep.content).includes("ALPHA"),
+      "Grep still searches ordinary workspace files",
+      toolResultText(normalGrep.content),
+    );
+    const normalGlob = await call(globTool, { path: workspace, pattern: "**/*.txt" }, workspace);
+    check(
+      normalGlob.isError !== true &&
+        toolResultText(normalGlob.content).startsWith(`Matched files under ${workspace}:`) &&
+        toolResultText(normalGlob.content).includes("normal.txt"),
+      "Glob still discovers ordinary workspace files",
+      toolResultText(normalGlob.content),
+    );
+
     const outsideFile = path.join(outside, "secret.txt");
     const escapeFile = path.join(workspace, "escape.txt");
     await fs.writeFile(outsideFile, "outside-secret\n", "utf8");
@@ -83,6 +172,11 @@ async function main(): Promise<void> {
     process.stdout.write("File tools reject links that escape an allowed root\n");
     const readEscape = await call(fileReadTool, { file_path: escapeFile }, workspace);
     check(readEscape.isError === true, "Read rejects an escaping file link", toolResultText(readEscape.content));
+    check(
+      toolResultText(readEscape.content).startsWith("Error: Path resolves outside"),
+      "Boundary failures preserve the existing tool error prefix",
+      toolResultText(readEscape.content),
+    );
 
     const writeEscape = await call(
       fileWriteTool,
@@ -204,6 +298,16 @@ async function main(): Promise<void> {
       (await call(fileReadTool, { file_path: internalDirectoryLink }, workspace)).isError !== true,
       "Read accepts an internal directory link",
     );
+    const internalGlob = await call(
+      globTool,
+      { path: internalDirectoryLink, pattern: "**/*.txt" },
+      workspace,
+    );
+    check(
+      toolResultText(internalGlob.content).startsWith(`Matched files under ${internalDirectoryLink}:`),
+      "Glob keeps the requested path in normal result text",
+      toolResultText(internalGlob.content),
+    );
 
     const nestedFile = path.join(workspace, "new", "nested", "file.txt");
     check(
@@ -216,6 +320,14 @@ async function main(): Promise<void> {
       "Write overwrites an existing regular file",
     );
     check((await fs.readFile(nestedFile, "utf8")) === "overwritten\n", "Overwrite replaces the complete file");
+    if (process.platform !== "win32") {
+      await fs.chmod(nestedFile, 0o640);
+      await call(fileWriteTool, { file_path: nestedFile, content: "mode-preserved\n" }, workspace);
+      check(
+        ((await fs.stat(nestedFile)).mode & 0o777) === 0o640,
+        "Overwriting an existing file preserves its mode",
+      );
+    }
 
     setAdditionalAllowedRoots([additional]);
     const additionalFile = path.join(additional, "allowed.txt");
@@ -326,6 +438,25 @@ async function main(): Promise<void> {
     check(
       (await fs.readFile(raceOutside, "utf8")) === "outside-race\n",
       "Rewind does not follow a replacement link outside the workspace",
+    );
+
+    const createdAfterSnapshot = path.join(workspace, "created-after-snapshot.txt");
+    const internalVictim = path.join(workspace, "internal-victim.txt");
+    await fs.writeFile(internalVictim, "keep-internal-victim\n", "utf8");
+    await configureFileHistory(workspace, "boundary-created-replacement");
+    await fileHistoryMakeSnapshot("created-replacement");
+    await fileHistoryTrackEdit(createdAfterSnapshot, "created-replacement");
+    await fs.writeFile(createdAfterSnapshot, "new-file\n", "utf8");
+    await fs.unlink(createdAfterSnapshot);
+    await createFileSymlink(internalVictim, createdAfterSnapshot);
+    await fileHistoryRewind("created-replacement");
+    check(
+      (await fs.readFile(internalVictim, "utf8")) === "keep-internal-victim\n",
+      "Rewind never deletes the target of a replacement link",
+    );
+    check(
+      await fs.lstat(createdAfterSnapshot).then(() => false, () => true),
+      "Rewind removes the replacement link when restoring a missing path",
     );
 
     const historySource = path.join(workspace, "history-source.txt");

--- a/src/scripts/test-path-boundary.ts
+++ b/src/scripts/test-path-boundary.ts
@@ -155,11 +155,15 @@ async function main(): Promise<void> {
       "Grep still searches ordinary workspace files",
       toolResultText(normalGrep.content),
     );
+    const hiddenDirectory = path.join(workspace, ".hidden");
+    await fs.mkdir(hiddenDirectory);
+    await fs.writeFile(path.join(hiddenDirectory, "visible-to-glob.txt"), "hidden\n", "utf8");
     const normalGlob = await call(globTool, { path: workspace, pattern: "**/*.txt" }, workspace);
     check(
       normalGlob.isError !== true &&
         toolResultText(normalGlob.content).startsWith(`Matched files under ${workspace}:`) &&
-        toolResultText(normalGlob.content).includes("normal.txt"),
+        toolResultText(normalGlob.content).includes("normal.txt") &&
+        toolResultText(normalGlob.content).includes("visible-to-glob.txt"),
       "Glob still discovers ordinary workspace files",
       toolResultText(normalGlob.content),
     );

--- a/src/scripts/test-stage32.ts
+++ b/src/scripts/test-stage32.ts
@@ -72,6 +72,17 @@ async function main(): Promise<void> {
   await fs.writeFile(big, Buffer.alloc(MAX_IMAGE_BYTES + 1024));
   const bigRes = await readImageAsBlock(big);
   assert(!bigRes.ok && /too large/i.test((bigRes as { error: string }).error), "oversized image rejected by guard");
+  const bigRead = await fileReadTool.call({ file_path: big }, { cwd: tmp });
+  assert(
+    bigRead.isError === true && /too large/i.test(toolResultText(bigRead.content)),
+    "Read rejects an oversized image before producing an image block",
+  );
+  const bigAttachment = await buildUserMessageContent(`look at @${big}`, tmp);
+  assert(
+    typeof bigAttachment.content === "string" &&
+      bigAttachment.errors.some((error) => /too large/i.test(error)),
+    "@image rejects an oversized image without attaching it",
+  );
 
   // ── [2] Read tool reads an image into an ImageBlock ───────────────────────
   section("[2] Read tool → ImageBlock");
@@ -106,6 +117,7 @@ async function main(): Promise<void> {
   const missing = await buildUserMessageContent("look at @does-not-exist.png", process.cwd());
   assert(typeof missing.content === "string", "missing image → plain string (no crash)");
   assert(missing.errors.length === 1, "missing image surfaces one error");
+  assert(missing.errors[0]?.includes("Image not found:") === true, "missing image keeps its user-facing error text");
 
   // Pasted / clipboard image: `[Image #N]` chip resolves from the in-memory
   // registry (no filesystem path, no allowed-roots check).

--- a/src/scripts/test-tool-card-format.ts
+++ b/src/scripts/test-tool-card-format.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { summarizeTool } from "../ui/utils/toolCardFormat.js";
+
+const pending = summarizeTool("Skill", {
+  skill: "demo:greet",
+  args: "Ada",
+});
+assert.deepEqual(pending, {
+  label: "Skill",
+  target: "demo:greet Ada",
+  stat: undefined,
+});
+
+const loaded = summarizeTool(
+  "Skill",
+  { skill: "demo:greet", args: "Ada" },
+  'Loaded skill "demo:greet" (project).\n\nFollow the instructions below.',
+);
+assert.deepEqual(loaded, {
+  label: "Skill",
+  target: "demo:greet Ada",
+  stat: "loaded",
+});
+
+const failed = summarizeTool(
+  "Skill",
+  { skill: "missing" },
+  'Skill "missing" not found.',
+);
+assert.deepEqual(failed, {
+  label: "Skill",
+  target: "missing",
+  stat: undefined,
+});
+
+process.stdout.write("Skill tool-card formatting passed.\n");

--- a/src/session/fileHistory.ts
+++ b/src/session/fileHistory.ts
@@ -29,6 +29,7 @@
 import { createHash } from "node:crypto";
 import { constants, type Stats } from "node:fs";
 import {
+  type FileHandle,
   mkdir,
   open,
   readdir,
@@ -44,8 +45,9 @@ import {
   readWorkspaceFile,
   removeWorkspaceFile,
   resolveWorkspacePathForWrite,
+  withValidatedWorkspaceFile,
   withValidatedWorkspacePath,
-  writeWorkspaceFile,
+  writeWorkspaceFileFromHandle,
 } from "../tools/pathUtils.js";
 import {
   DEFAULT_CLEANUP_PERIOD_DAYS,
@@ -471,58 +473,99 @@ async function createBackup(
   const backupFileName = getBackupFileName(filePath, version);
   const backupPath = resolveBackupPath(backupFileName);
 
-  let source: Awaited<ReturnType<typeof readWorkspaceFile>>;
   try {
-    source = await readWorkspaceFile(filePath, cwd);
+    await withValidatedWorkspaceFile(
+      filePath,
+      cwd,
+      async (sourceHandle, _resolution, sourceStats) => {
+        await writeBackupFile(backupPath, sourceHandle, sourceStats.mode);
+      },
+    );
   } catch (e) {
     if (isENOENT(e)) return { backupFileName: null, version, backupTime };
     throw e;
   }
-
-  await writeBackupFile(backupPath, source.data, source.stats.mode);
 
   return { backupFileName, version, backupTime };
 }
 
 async function restoreBackup(filePath: string, backupFileName: string): Promise<void> {
   const backupPath = resolveBackupPath(backupFileName);
-  let backup: { data: Buffer; stats: Stats };
   try {
-    backup = await readBackupFile(backupPath);
+    await withBackupFile(backupPath, async (backupHandle, backupStats) => {
+      await writeWorkspaceFileFromHandle(filePath, cwd, backupHandle, {
+        mode: backupStats.mode,
+      });
+    });
   } catch (e) {
     if (isENOENT(e)) return;
     throw e;
   }
-
-  await writeWorkspaceFile(filePath, cwd, backup.data, { mode: backup.stats.mode });
 }
 
-async function writeBackupFile(filePath: string, data: Buffer, mode: number): Promise<void> {
+async function copyHandleContents(sourceHandle: FileHandle, targetHandle: FileHandle): Promise<void> {
+  await targetHandle.truncate(0);
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  let offset = 0;
+  for (;;) {
+    const { bytesRead } = await sourceHandle.read(buffer, 0, buffer.length, offset);
+    if (bytesRead === 0) return;
+
+    let written = 0;
+    while (written < bytesRead) {
+      const result = await targetHandle.write(
+        buffer,
+        written,
+        bytesRead - written,
+        offset + written,
+      );
+      if (result.bytesWritten === 0) throw new Error("Backup write made no progress");
+      written += result.bytesWritten;
+    }
+    offset += bytesRead;
+  }
+}
+
+async function writeBackupFile(
+  filePath: string,
+  sourceHandle: FileHandle,
+  mode: number,
+): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });
   const handle = await open(
     filePath,
-    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0),
+    constants.O_WRONLY | constants.O_CREAT | (constants.O_NOFOLLOW ?? 0),
     mode,
   );
   try {
     const stats = await handle.stat();
     if (!stats.isFile()) throw new Error(`Backup path is not a regular file: ${filePath}`);
-    await handle.writeFile(data);
+    await copyHandleContents(sourceHandle, handle);
     await handle.chmod(mode);
   } finally {
     await handle.close().catch(() => {});
   }
 }
 
-async function readBackupFile(filePath: string): Promise<{ data: Buffer; stats: Stats }> {
+async function withBackupFile<T>(
+  filePath: string,
+  operation: (handle: FileHandle, stats: Stats) => Promise<T>,
+): Promise<T> {
   const handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
   try {
     const stats = await handle.stat();
     if (!stats.isFile()) throw new Error(`Backup path is not a regular file: ${filePath}`);
-    return { data: await handle.readFile(), stats };
+    return await operation(handle, stats);
   } finally {
     await handle.close().catch(() => {});
   }
+}
+
+async function readBackupFile(filePath: string): Promise<{ data: Buffer; stats: Stats }> {
+  return withBackupFile(filePath, async (handle, stats) => ({
+    data: await handle.readFile(),
+    stats,
+  }));
 }
 
 /**
@@ -545,29 +588,85 @@ function getBackupFileNameFirstVersion(trackingPath: string): BackupFileName | u
 export async function checkOriginFileChanged(
   originalFile: string,
   backupFileName: string,
-  _originalStatsHint?: Stats,
+  originalStatsHint?: Stats,
 ): Promise<boolean> {
   const backupPath = resolveBackupPath(backupFileName);
 
-  let original: Awaited<ReturnType<typeof readWorkspaceFile>> | null = null;
-  try {
-    original = await readWorkspaceFile(originalFile, cwd);
-  } catch (e) {
-    if (!isENOENT(e)) return true;
+  let originalStats: Stats | null = originalStatsHint ?? null;
+  if (!originalStats) {
+    try {
+      originalStats = await withValidatedWorkspacePath(
+        originalFile,
+        cwd,
+        async (_resolvedPath, stats) => stats,
+      );
+    } catch (e) {
+      if (!isENOENT(e)) return true;
+    }
   }
-  let backup: { data: Buffer; stats: Stats } | null = null;
+
+  let backupStats: Stats | null = null;
   try {
-    backup = await readBackupFile(backupPath);
+    backupStats = await withBackupFile(backupPath, async (_handle, stats) => stats);
   } catch (e) {
     if (!isENOENT(e)) return true;
   }
 
-  if ((original === null) !== (backup === null)) return true;
-  if (original === null || backup === null) return false;
-  if (original.stats.mode !== backup.stats.mode || original.stats.size !== backup.stats.size) {
+  if ((originalStats === null) !== (backupStats === null)) return true;
+  if (originalStats === null || backupStats === null) return false;
+  if (originalStats.mode !== backupStats.mode || originalStats.size !== backupStats.size) {
     return true;
   }
-  return !original.data.equals(backup.data);
+  if (originalStats.mtimeMs < backupStats.mtimeMs) return false;
+
+  try {
+    return await withValidatedWorkspaceFile(
+      originalFile,
+      cwd,
+      async (originalHandle, _resolution, currentOriginalStats) =>
+        withBackupFile(backupPath, async (backupHandle, currentBackupStats) => {
+          if (
+            currentOriginalStats.mode !== currentBackupStats.mode ||
+            currentOriginalStats.size !== currentBackupStats.size
+          ) {
+            return true;
+          }
+          return !(await fileHandlesEqual(
+            originalHandle,
+            backupHandle,
+            currentOriginalStats.size,
+          ));
+        }),
+    );
+  } catch {
+    return true;
+  }
+}
+
+async function fileHandlesEqual(
+  left: FileHandle,
+  right: FileHandle,
+  size: number,
+): Promise<boolean> {
+  const leftBuffer = Buffer.allocUnsafe(64 * 1024);
+  const rightBuffer = Buffer.allocUnsafe(64 * 1024);
+  let offset = 0;
+  while (offset < size) {
+    const length = Math.min(leftBuffer.length, size - offset);
+    const [leftRead, rightRead] = await Promise.all([
+      left.read(leftBuffer, 0, length, offset),
+      right.read(rightBuffer, 0, length, offset),
+    ]);
+    if (leftRead.bytesRead !== rightRead.bytesRead) return false;
+    if (!leftBuffer.subarray(0, leftRead.bytesRead).equals(
+      rightBuffer.subarray(0, rightRead.bytesRead),
+    )) {
+      return false;
+    }
+    if (leftRead.bytesRead === 0) return offset === size;
+    offset += leftRead.bytesRead;
+  }
+  return true;
 }
 
 async function computeDiffStatsForFile(

--- a/src/session/fileHistory.ts
+++ b/src/session/fileHistory.ts
@@ -27,21 +27,26 @@
  */
 
 import { createHash } from "node:crypto";
-import { Stats } from "node:fs";
+import { constants, type Stats } from "node:fs";
 import {
-  chmod,
-  copyFile,
   mkdir,
+  open,
   readdir,
   readFile,
   rm,
   stat,
-  unlink,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { diffLines } from "diff";
 import { getEasyAgentHome } from "../utils/paths.js";
 import { readMergedBooleanSetting, readMergedNumberSetting } from "../utils/settings.js";
+import {
+  readWorkspaceFile,
+  removeWorkspaceFile,
+  resolveWorkspacePathForWrite,
+  withValidatedWorkspacePath,
+  writeWorkspaceFile,
+} from "../tools/pathUtils.js";
 import {
   DEFAULT_CLEANUP_PERIOD_DAYS,
   recordFileHistorySnapshot,
@@ -219,7 +224,13 @@ export async function fileHistoryTrackEdit(
 ): Promise<void> {
   if (!enabled) return;
 
-  const trackingPath = maybeShortenFilePath(filePath);
+  let checkedPath: string;
+  try {
+    checkedPath = (await resolveWorkspacePathForWrite(filePath, cwd)).requestedPath;
+  } catch {
+    return;
+  }
+  const trackingPath = maybeShortenFilePath(checkedPath);
 
   // Ensure there's a snapshot to attach to. In normal operation makeSnapshot
   // fires at turn start, but track-before-snapshot must not silently drop the
@@ -241,7 +252,7 @@ export async function fileHistoryTrackEdit(
 
   let backup: FileHistoryBackup;
   try {
-    backup = await createBackup(filePath, 1);
+    backup = await createBackup(checkedPath, 1);
   } catch {
     return;
   }
@@ -275,7 +286,14 @@ export async function fileHistoryMakeSnapshot(messageId: string): Promise<void> 
 
         let fileStats: Stats | undefined;
         try {
-          fileStats = await stat(filePath);
+          const resolution = await resolveWorkspacePathForWrite(filePath, cwd);
+          if (resolution.exists) {
+            fileStats = await withValidatedWorkspacePath(
+              filePath,
+              cwd,
+              async (_resolvedPath, stats) => stats,
+            );
+          }
         } catch (e) {
           if (!isENOENT(e)) throw e;
         }
@@ -409,10 +427,10 @@ async function applySnapshot(target: FileHistorySnapshot): Promise<string[]> {
       if (backupFileName === undefined) continue;
 
       if (backupFileName === null) {
-        // File did not exist at the target version; delete it if present.
         try {
-          await unlink(filePath);
-          filesChanged.push(filePath);
+          if (await removeWorkspaceFile(filePath, cwd)) {
+            filesChanged.push(filePath);
+          }
         } catch (e) {
           if (!isENOENT(e)) throw e;
         }
@@ -453,44 +471,58 @@ async function createBackup(
   const backupFileName = getBackupFileName(filePath, version);
   const backupPath = resolveBackupPath(backupFileName);
 
-  let srcStats: Stats;
+  let source: Awaited<ReturnType<typeof readWorkspaceFile>>;
   try {
-    srcStats = await stat(filePath);
+    source = await readWorkspaceFile(filePath, cwd);
   } catch (e) {
     if (isENOENT(e)) return { backupFileName: null, version, backupTime };
     throw e;
   }
 
-  try {
-    await copyFile(filePath, backupPath);
-  } catch (e) {
-    if (!isENOENT(e)) throw e;
-    await mkdir(dirname(backupPath), { recursive: true });
-    await copyFile(filePath, backupPath);
-  }
-  await chmod(backupPath, srcStats.mode);
+  await writeBackupFile(backupPath, source.data, source.stats.mode);
 
   return { backupFileName, version, backupTime };
 }
 
 async function restoreBackup(filePath: string, backupFileName: string): Promise<void> {
   const backupPath = resolveBackupPath(backupFileName);
-  let backupStats: Stats;
+  let backup: { data: Buffer; stats: Stats };
   try {
-    backupStats = await stat(backupPath);
+    backup = await readBackupFile(backupPath);
   } catch (e) {
     if (isENOENT(e)) return;
     throw e;
   }
 
+  await writeWorkspaceFile(filePath, cwd, backup.data, { mode: backup.stats.mode });
+}
+
+async function writeBackupFile(filePath: string, data: Buffer, mode: number): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const handle = await open(
+    filePath,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0),
+    mode,
+  );
   try {
-    await copyFile(backupPath, filePath);
-  } catch (e) {
-    if (!isENOENT(e)) throw e;
-    await mkdir(dirname(filePath), { recursive: true });
-    await copyFile(backupPath, filePath);
+    const stats = await handle.stat();
+    if (!stats.isFile()) throw new Error(`Backup path is not a regular file: ${filePath}`);
+    await handle.writeFile(data);
+    await handle.chmod(mode);
+  } finally {
+    await handle.close().catch(() => {});
   }
-  await chmod(filePath, backupStats.mode);
+}
+
+async function readBackupFile(filePath: string): Promise<{ data: Buffer; stats: Stats }> {
+  const handle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const stats = await handle.stat();
+    if (!stats.isFile()) throw new Error(`Backup path is not a regular file: ${filePath}`);
+    return { data: await handle.readFile(), stats };
+  } finally {
+    await handle.close().catch(() => {});
+  }
 }
 
 /**
@@ -513,45 +545,29 @@ function getBackupFileNameFirstVersion(trackingPath: string): BackupFileName | u
 export async function checkOriginFileChanged(
   originalFile: string,
   backupFileName: string,
-  originalStatsHint?: Stats,
+  _originalStatsHint?: Stats,
 ): Promise<boolean> {
   const backupPath = resolveBackupPath(backupFileName);
 
-  let originalStats: Stats | null = originalStatsHint ?? null;
-  if (!originalStats) {
-    try {
-      originalStats = await stat(originalFile);
-    } catch (e) {
-      if (!isENOENT(e)) return true;
-    }
-  }
-  let backupStats: Stats | null = null;
+  let original: Awaited<ReturnType<typeof readWorkspaceFile>> | null = null;
   try {
-    backupStats = await stat(backupPath);
+    original = await readWorkspaceFile(originalFile, cwd);
+  } catch (e) {
+    if (!isENOENT(e)) return true;
+  }
+  let backup: { data: Buffer; stats: Stats } | null = null;
+  try {
+    backup = await readBackupFile(backupPath);
   } catch (e) {
     if (!isENOENT(e)) return true;
   }
 
-  // One exists, one missing → changed.
-  if ((originalStats === null) !== (backupStats === null)) return true;
-  // Both missing → unchanged.
-  if (originalStats === null || backupStats === null) return false;
-  // Cheap stat comparison first.
-  if (originalStats.mode !== backupStats.mode || originalStats.size !== backupStats.size) {
+  if ((original === null) !== (backup === null)) return true;
+  if (original === null || backup === null) return false;
+  if (original.stats.mode !== backup.stats.mode || original.stats.size !== backup.stats.size) {
     return true;
   }
-  // If original is older than the backup, content can't have diverged.
-  if (originalStats.mtimeMs < backupStats.mtimeMs) return false;
-
-  try {
-    const [a, b] = await Promise.all([
-      readFile(originalFile, "utf-8"),
-      readFile(backupPath, "utf-8"),
-    ]);
-    return a !== b;
-  } catch {
-    return true;
-  }
+  return !original.data.equals(backup.data);
 }
 
 async function computeDiffStatsForFile(
@@ -563,7 +579,10 @@ async function computeDiffStatsForFile(
   try {
     const backupPath = backupFileName ? resolveBackupPath(backupFileName) : undefined;
     const [originalContent, backupContent] = await Promise.all([
-      readFileOrNull(originalFile),
+      readWorkspaceFile(originalFile, cwd).then(
+        (file) => file.data.toString("utf8"),
+        () => null,
+      ),
       backupPath ? readFileOrNull(backupPath) : Promise.resolve(null),
     ]);
     if (originalContent === null && backupContent === null) {
@@ -593,7 +612,10 @@ async function readFileOrNull(path: string): Promise<string | null> {
 /** Store tracked files relative to cwd when possible (smaller transcript). */
 function maybeShortenFilePath(filePath: string): string {
   if (!isAbsolute(filePath)) return filePath;
-  if (filePath.startsWith(cwd)) return relative(cwd, filePath);
+  const relativePath = relative(cwd, filePath);
+  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+    return relativePath;
+  }
   return filePath;
 }
 

--- a/src/tools/fileEditTool.ts
+++ b/src/tools/fileEditTool.ts
@@ -1,5 +1,9 @@
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveSafePath, updateWorkspaceTextFile } from "./pathUtils.js";
+import {
+  resolveSafePath,
+  updateWorkspaceTextFile,
+  WorkspacePathError,
+} from "./pathUtils.js";
 import {
   applyEditToContent,
   buildEditPreview,
@@ -66,6 +70,9 @@ export const fileEditTool: Tool = {
           content: `Error: ${error.message} in ${resolveSafePath(input.file_path, context.cwd)}`,
           isError: true,
         };
+      }
+      if (error instanceof WorkspacePathError) {
+        return { content: `Error: ${error.message}`, isError: true };
       }
       return {
         content: `Error editing file: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/tools/fileEditTool.ts
+++ b/src/tools/fileEditTool.ts
@@ -1,6 +1,5 @@
-import * as fs from "node:fs/promises";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveWorkspacePath } from "./pathUtils.js";
+import { resolveSafePath, updateWorkspaceTextFile } from "./pathUtils.js";
 import {
   applyEditToContent,
   buildEditPreview,
@@ -44,46 +43,30 @@ export const fileEditTool: Tool = {
       return { content: "Error: file_path, old_string, and new_string are required", isError: true };
     }
 
-    let resolvedPath: string;
     try {
-      resolvedPath = resolveWorkspacePath(input.file_path, context.cwd);
-    } catch (error: unknown) {
-      return {
-        content: error instanceof Error ? `Error: ${error.message}` : `Error: ${String(error)}`,
-        isError: true,
-      };
-    }
-
-    try {
-      const original = await fs.readFile(resolvedPath, "utf-8");
-
-      let updated: string;
-      let replacements: number;
-      try {
-        const result = applyEditToContent(original, {
+      const result = await updateWorkspaceTextFile(input.file_path, context.cwd, (original) => {
+        const edit = applyEditToContent(original, {
           old_string: input.old_string,
           new_string: input.new_string,
           replace_all: input.replace_all === true,
         });
-        updated = result.content;
-        replacements = result.replacements;
-      } catch (error) {
-        if (error instanceof EditError) {
-          return { content: `Error: ${error.message} in ${resolvedPath}`, isError: true };
-        }
-        throw error;
-      }
+        return { content: edit.content, value: edit.replacements };
+      });
 
-      await fs.writeFile(resolvedPath, updated, "utf-8");
-
-      const countNote = replacements > 1 ? ` (${replacements} occurrences)` : "";
+      const countNote = result.value > 1 ? ` (${result.value} occurrences)` : "";
       return {
-        content: `Updated file: ${resolvedPath}${countNote}\n${buildEditPreview(
+        content: `Updated file: ${result.requestedPath}${countNote}\n${buildEditPreview(
           normalizeQuotes(input.old_string),
           normalizeQuotes(input.new_string),
         )}`,
       };
     } catch (error: unknown) {
+      if (error instanceof EditError) {
+        return {
+          content: `Error: ${error.message} in ${resolveSafePath(input.file_path, context.cwd)}`,
+          isError: true,
+        };
+      }
       return {
         content: `Error editing file: ${error instanceof Error ? error.message : String(error)}`,
         isError: true,

--- a/src/tools/fileReadTool.ts
+++ b/src/tools/fileReadTool.ts
@@ -2,10 +2,9 @@
  * FileReadTool — Read file contents with optional line range.
  */
 
-import * as fs from "node:fs/promises";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveWorkspacePath } from "./pathUtils.js";
-import { isImagePath, readImageAsBlock } from "./imageUtils.js";
+import { readWorkspaceEntry } from "./pathUtils.js";
+import { imageBufferAsBlock, isImagePath } from "./imageUtils.js";
 
 interface FileReadInput {
   file_path: string;
@@ -54,31 +53,17 @@ export const fileReadTool: Tool = {
       return { content: "Error: file_path is required", isError: true };
     }
 
-    let resolvedPath: string;
-    try {
-      resolvedPath = resolveWorkspacePath(input.file_path, context.cwd);
-    } catch (error: unknown) {
-      return {
-        content: error instanceof Error ? `Error: ${error.message}` : `Error: ${String(error)}`,
-        isError: true,
-      };
-    }
-
     const offset = input.offset ?? 1;
     const limit = input.limit;
 
     try {
-      const stat = await fs.stat(resolvedPath);
-      if (stat.isDirectory()) {
-        const entries = await fs.readdir(resolvedPath);
-        return { content: `Directory listing for ${input.file_path}:\n${entries.join("\n")}` };
+      const entry = await readWorkspaceEntry(input.file_path, context.cwd);
+      if (entry.kind === "directory") {
+        return { content: `Directory listing for ${input.file_path}:\n${entry.entries.join("\n")}` };
       }
 
-      // Images come back as a real image block so the model can see them,
-      // prefixed with a short text note for context. Non-image binaries fall
-      // through to the UTF-8 text path below.
-      if (isImagePath(resolvedPath)) {
-        const img = await readImageAsBlock(resolvedPath);
+      if (isImagePath(entry.requestedPath)) {
+        const img = imageBufferAsBlock(entry.requestedPath, entry.data);
         if (!img.ok) {
           return { content: `Error: ${img.error}`, isError: true };
         }
@@ -90,7 +75,7 @@ export const fileReadTool: Tool = {
         };
       }
 
-      const raw = await fs.readFile(resolvedPath, "utf-8");
+      const raw = entry.data.toString("utf8");
       const allLines = raw.split("\n");
       const startIdx = Math.max(0, offset - 1);
       const endIdx = limit ? startIdx + limit : allLines.length;
@@ -102,7 +87,7 @@ export const fileReadTool: Tool = {
           ? ` (lines ${startIdx + 1}-${startIdx + numLines} of ${allLines.length})`
           : ` (${allLines.length} lines)`;
 
-      return { content: `${resolvedPath}${rangeInfo}\n${numbered}` };
+      return { content: `${entry.requestedPath}${rangeInfo}\n${numbered}` };
     } catch (error: unknown) {
       const err = error as NodeJS.ErrnoException;
       if (err.code === "ENOENT") {

--- a/src/tools/fileReadTool.ts
+++ b/src/tools/fileReadTool.ts
@@ -3,8 +3,17 @@
  */
 
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { readWorkspaceEntry } from "./pathUtils.js";
-import { imageBufferAsBlock, isImagePath } from "./imageUtils.js";
+import {
+  readWorkspaceEntry,
+  WorkspaceFileTooLargeError,
+  WorkspacePathError,
+} from "./pathUtils.js";
+import {
+  formatImageSizeError,
+  imageBufferAsBlock,
+  isImagePath,
+  MAX_IMAGE_BYTES,
+} from "./imageUtils.js";
 
 interface FileReadInput {
   file_path: string;
@@ -55,9 +64,12 @@ export const fileReadTool: Tool = {
 
     const offset = input.offset ?? 1;
     const limit = input.limit;
+    const imagePath = isImagePath(input.file_path);
 
     try {
-      const entry = await readWorkspaceEntry(input.file_path, context.cwd);
+      const entry = await readWorkspaceEntry(input.file_path, context.cwd, {
+        ...(imagePath ? { maxFileBytes: MAX_IMAGE_BYTES } : {}),
+      });
       if (entry.kind === "directory") {
         return { content: `Directory listing for ${input.file_path}:\n${entry.entries.join("\n")}` };
       }
@@ -89,6 +101,12 @@ export const fileReadTool: Tool = {
 
       return { content: `${entry.requestedPath}${rangeInfo}\n${numbered}` };
     } catch (error: unknown) {
+      if (error instanceof WorkspacePathError) {
+        return { content: `Error: ${error.message}`, isError: true };
+      }
+      if (error instanceof WorkspaceFileTooLargeError && imagePath) {
+        return { content: `Error: ${formatImageSizeError(error.actualBytes)}`, isError: true };
+      }
       const err = error as NodeJS.ErrnoException;
       if (err.code === "ENOENT") {
         return { content: `Error: File not found: ${input.file_path}`, isError: true };

--- a/src/tools/fileWriteTool.ts
+++ b/src/tools/fileWriteTool.ts
@@ -1,5 +1,5 @@
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { writeWorkspaceFile } from "./pathUtils.js";
+import { WorkspacePathError, writeWorkspaceFile } from "./pathUtils.js";
 
 interface FileWriteInput {
   file_path: string;
@@ -34,6 +34,9 @@ export const fileWriteTool: Tool = {
         content: `${result.existed ? "Updated" : "Created"} file: ${result.requestedPath} (${input.content.length} chars)`,
       };
     } catch (error: unknown) {
+      if (error instanceof WorkspacePathError) {
+        return { content: `Error: ${error.message}`, isError: true };
+      }
       return {
         content: `Error writing file: ${error instanceof Error ? error.message : String(error)}`,
         isError: true,

--- a/src/tools/fileWriteTool.ts
+++ b/src/tools/fileWriteTool.ts
@@ -1,7 +1,5 @@
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveWorkspacePath } from "./pathUtils.js";
+import { writeWorkspaceFile } from "./pathUtils.js";
 
 interface FileWriteInput {
   file_path: string;
@@ -29,29 +27,11 @@ export const fileWriteTool: Tool = {
       return { content: "Error: content must be a string", isError: true };
     }
 
-    let resolvedPath: string;
     try {
-      resolvedPath = resolveWorkspacePath(input.file_path, context.cwd);
-    } catch (error: unknown) {
-      return {
-        content: error instanceof Error ? `Error: ${error.message}` : `Error: ${String(error)}`,
-        isError: true,
-      };
-    }
-
-    try {
-      let existed = true;
-      try {
-        await fs.access(resolvedPath);
-      } catch {
-        existed = false;
-      }
-
-      await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
-      await fs.writeFile(resolvedPath, input.content, "utf-8");
+      const result = await writeWorkspaceFile(input.file_path, context.cwd, input.content);
 
       return {
-        content: `${existed ? "Updated" : "Created"} file: ${resolvedPath} (${input.content.length} chars)`,
+        content: `${result.existed ? "Updated" : "Created"} file: ${result.requestedPath} (${input.content.length} chars)`,
       };
     } catch (error: unknown) {
       return {

--- a/src/tools/globTool.ts
+++ b/src/tools/globTool.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveWorkspacePath } from "./pathUtils.js";
+import { withValidatedWorkspacePath } from "./pathUtils.js";
 import { readMergedBooleanSetting } from "../utils/settings.js";
 
 const execFileAsync = promisify(execFile);
@@ -38,41 +38,35 @@ export const globTool: Tool = {
       return { content: "Error: pattern is required", isError: true };
     }
 
-    let basePath: string;
-    try {
-      basePath = resolveWorkspacePath(input.path ?? ".", context.cwd);
-    } catch (error: unknown) {
-      return {
-        content: error instanceof Error ? `Error: ${error.message}` : `Error: ${String(error)}`,
-        isError: true,
-      };
-    }
-
-    // respectGitignore (default true): when explicitly false, surface files
-    // that .gitignore would otherwise hide by passing rg's --no-ignore.
     const respectGitignore = (await readMergedBooleanSetting(context.cwd, "respectGitignore").catch(() => undefined)) !== false;
 
     try {
-      if (await hasCommand("rg")) {
-        const rgArgs = ["--files", "--hidden", "-g", input.pattern];
-        if (!respectGitignore) rgArgs.push("--no-ignore");
-        const { stdout } = await execFileAsync("rg", rgArgs, {
-          cwd: basePath,
-          maxBuffer: 1024 * 1024,
-        });
-        const output = stdout.trim();
-        return {
-          content: output ? `Matched files under ${basePath}:\n${output}` : `No files matched ${input.pattern}`,
-        };
-      }
+      return await withValidatedWorkspacePath(
+        input.path ?? ".",
+        context.cwd,
+        async (basePath) => {
+          if (await hasCommand("rg")) {
+            const rgArgs = ["--files", "--hidden", "-g", input.pattern];
+            if (!respectGitignore) rgArgs.push("--no-ignore");
+            const { stdout } = await execFileAsync("rg", rgArgs, {
+              cwd: basePath,
+              maxBuffer: 1024 * 1024,
+            });
+            const output = stdout.trim();
+            return {
+              content: output ? `Matched files under ${basePath}:\n${output}` : `No files matched ${input.pattern}`,
+            };
+          }
 
-      const { stdout } = await execFileAsync("find", [basePath, "-path", `*${input.pattern.replace(/\*\*/g, "*")}`], {
-        maxBuffer: 1024 * 1024,
-      });
-      const output = stdout.trim();
-      return {
-        content: output ? `Matched files under ${basePath}:\n${output}` : `No files matched ${input.pattern}`,
-      };
+          const { stdout } = await execFileAsync("find", [basePath, "-path", `*${input.pattern.replace(/\*\*/g, "*")}`], {
+            maxBuffer: 1024 * 1024,
+          });
+          const output = stdout.trim();
+          return {
+            content: output ? `Matched files under ${basePath}:\n${output}` : `No files matched ${input.pattern}`,
+          };
+        },
+      );
     } catch (error: unknown) {
       return {
         content: `Error running glob search: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/tools/globTool.ts
+++ b/src/tools/globTool.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import * as path from "node:path";
 import { promisify } from "node:util";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
 import {
@@ -22,6 +24,27 @@ async function hasCommand(command: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function matchesGlob(candidate: string, pattern: string): boolean {
+  const normalizedCandidate = candidate.split(path.sep).join("/");
+  const normalizedPattern = pattern.split("\\").join("/");
+  if (path.posix.matchesGlob(normalizedCandidate, normalizedPattern)) return true;
+
+  const withoutLeadingDots = normalizedCandidate
+    .split("/")
+    .map((segment) => segment.startsWith(".") ? segment.slice(1) : segment)
+    .join("/");
+  return path.posix.matchesGlob(withoutLeadingDots, normalizedPattern);
+}
+
+async function findFilesWithNode(basePath: string, pattern: string): Promise<string[]> {
+  const entries = await readdir(basePath, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() || entry.isSymbolicLink())
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .filter((filePath) => matchesGlob(path.relative(basePath, filePath), pattern))
+    .sort((left, right) => left.localeCompare(right));
 }
 
 export const globTool: Tool = {
@@ -63,10 +86,7 @@ export const globTool: Tool = {
             };
           }
 
-          const { stdout } = await execFileAsync("find", [basePath, "-path", `*${input.pattern.replace(/\*\*/g, "*")}`], {
-            maxBuffer: 1024 * 1024,
-          });
-          const output = stdout.trim();
+          const output = (await findFilesWithNode(basePath, input.pattern)).join("\n");
           return {
             content: output ? `Matched files under ${displayBasePath}:\n${output}` : `No files matched ${input.pattern}`,
           };

--- a/src/tools/globTool.ts
+++ b/src/tools/globTool.ts
@@ -1,7 +1,11 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { withValidatedWorkspacePath } from "./pathUtils.js";
+import {
+  resolveSafePath,
+  withValidatedWorkspacePath,
+  WorkspacePathError,
+} from "./pathUtils.js";
 import { readMergedBooleanSetting } from "../utils/settings.js";
 
 const execFileAsync = promisify(execFile);
@@ -39,6 +43,7 @@ export const globTool: Tool = {
     }
 
     const respectGitignore = (await readMergedBooleanSetting(context.cwd, "respectGitignore").catch(() => undefined)) !== false;
+    const displayBasePath = resolveSafePath(input.path ?? ".", context.cwd);
 
     try {
       return await withValidatedWorkspacePath(
@@ -54,7 +59,7 @@ export const globTool: Tool = {
             });
             const output = stdout.trim();
             return {
-              content: output ? `Matched files under ${basePath}:\n${output}` : `No files matched ${input.pattern}`,
+              content: output ? `Matched files under ${displayBasePath}:\n${output}` : `No files matched ${input.pattern}`,
             };
           }
 
@@ -63,11 +68,14 @@ export const globTool: Tool = {
           });
           const output = stdout.trim();
           return {
-            content: output ? `Matched files under ${basePath}:\n${output}` : `No files matched ${input.pattern}`,
+            content: output ? `Matched files under ${displayBasePath}:\n${output}` : `No files matched ${input.pattern}`,
           };
         },
       );
     } catch (error: unknown) {
+      if (error instanceof WorkspacePathError) {
+        return { content: `Error: ${error.message}`, isError: true };
+      }
       return {
         content: `Error running glob search: ${error instanceof Error ? error.message : String(error)}`,
         isError: true,

--- a/src/tools/grepTool.ts
+++ b/src/tools/grepTool.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { withValidatedWorkspacePath } from "./pathUtils.js";
+import { withValidatedWorkspacePath, WorkspacePathError } from "./pathUtils.js";
 import { readMergedBooleanSetting } from "../utils/settings.js";
 
 const execFileAsync = promisify(execFile);
@@ -74,6 +74,9 @@ export const grepTool: Tool = {
         }
       );
     } catch (error: unknown) {
+      if (error instanceof WorkspacePathError) {
+        return { content: `Error: ${error.message}`, isError: true };
+      }
       if ((error as { code?: unknown })?.code === 1) {
         return { content: `No matches found for pattern: ${input.pattern}` };
       }

--- a/src/tools/grepTool.ts
+++ b/src/tools/grepTool.ts
@@ -1,8 +1,7 @@
 import { execFile } from "node:child_process";
-import { stat } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveWorkspacePath } from "./pathUtils.js";
+import { withValidatedWorkspacePath } from "./pathUtils.js";
 import { readMergedBooleanSetting } from "../utils/settings.js";
 
 const execFileAsync = promisify(execFile);
@@ -17,14 +16,6 @@ async function hasCommand(command: string): Promise<boolean> {
   try {
     await execFileAsync("sh", ["-lc", `command -v ${command}`]);
     return true;
-  } catch {
-    return false;
-  }
-}
-
-async function isDirectory(filePath: string): Promise<boolean> {
-  try {
-    return (await stat(filePath)).isDirectory();
   } catch {
     return false;
   }
@@ -49,45 +40,39 @@ export const grepTool: Tool = {
       return { content: "Error: pattern is required", isError: true };
     }
 
-    let targetPath: string;
-    try {
-      targetPath = resolveWorkspacePath(input.path ?? ".", context.cwd);
-    } catch (error: unknown) {
-      return {
-        content: error instanceof Error ? `Error: ${error.message}` : `Error: ${String(error)}`,
-        isError: true,
-      };
-    }
-
-    // respectGitignore (default true): when explicitly false, search files
-    // .gitignore would otherwise exclude by passing rg's --no-ignore.
     const respectGitignore = (await readMergedBooleanSetting(context.cwd, "respectGitignore").catch(() => undefined)) !== false;
 
     try {
-      if (await hasCommand("rg")) {
-        const args = ["-n", "--hidden"];
-        if (!respectGitignore) args.push("--no-ignore");
-        if (input.include) {
-          args.push("-g", input.include);
-        }
-        const targetIsDirectory = await isDirectory(targetPath);
-        args.push(input.pattern, targetIsDirectory ? "." : targetPath);
-        const { stdout } = await execFileAsync("rg", args, {
-          cwd: targetIsDirectory ? targetPath : undefined,
-          maxBuffer: 1024 * 1024,
-        });
-        const output = stdout.trim();
-        return {
-          content: output ? output : `No matches found for pattern: ${input.pattern}`,
-        };
-      }
+      return await withValidatedWorkspacePath(
+        input.path ?? ".",
+        context.cwd,
+        async (targetPath, stats) => {
+          if (await hasCommand("rg")) {
+            const args = ["-n", "--hidden"];
+            if (!respectGitignore) args.push("--no-ignore");
+            if (input.include) {
+              args.push("-g", input.include);
+            }
+            const targetIsDirectory = stats.isDirectory();
+            args.push(input.pattern, targetIsDirectory ? "." : targetPath);
+            const { stdout } = await execFileAsync("rg", args, {
+              cwd: targetIsDirectory ? targetPath : undefined,
+              maxBuffer: 1024 * 1024,
+            });
+            const output = stdout.trim();
+            return {
+              content: output ? output : `No matches found for pattern: ${input.pattern}`,
+            };
+          }
 
-      const grepArgs = ["-RIn", input.pattern, targetPath];
-      const { stdout } = await execFileAsync("grep", grepArgs, { maxBuffer: 1024 * 1024 });
-      const output = stdout.trim();
-      return {
-        content: output ? output : `No matches found for pattern: ${input.pattern}`,
-      };
+          const grepArgs = ["-RIn", input.pattern, targetPath];
+          const { stdout } = await execFileAsync("grep", grepArgs, { maxBuffer: 1024 * 1024 });
+          const output = stdout.trim();
+          return {
+            content: output ? output : `No matches found for pattern: ${input.pattern}`,
+          };
+        }
+      );
     } catch (error: unknown) {
       if ((error as { code?: unknown })?.code === 1) {
         return { content: `No matches found for pattern: ${input.pattern}` };

--- a/src/tools/imageUtils.ts
+++ b/src/tools/imageUtils.ts
@@ -77,6 +77,12 @@ export type ReadImageResult =
   | { ok: true; block: ImageBlock; bytes: number; mediaType: string }
   | { ok: false; error: string };
 
+export function formatImageSizeError(bytes: number): string {
+  const mb = (bytes / (1024 * 1024)).toFixed(1);
+  const limit = (MAX_IMAGE_BYTES / (1024 * 1024)).toFixed(2);
+  return `Image too large (${mb} MB > ${limit} MB limit). Resize or compress it before sending.`;
+}
+
 export function imageBufferAsBlock(absPath: string, data: Buffer): ReadImageResult {
   const mediaType = imageMediaType(absPath);
   if (!mediaType) {
@@ -85,11 +91,9 @@ export function imageBufferAsBlock(absPath: string, data: Buffer): ReadImageResu
 
   const bytes = data.byteLength;
   if (bytes > MAX_IMAGE_BYTES) {
-    const mb = (bytes / (1024 * 1024)).toFixed(1);
-    const limit = (MAX_IMAGE_BYTES / (1024 * 1024)).toFixed(2);
     return {
       ok: false,
-      error: `Image too large (${mb} MB > ${limit} MB limit). Resize or compress it before sending.`,
+      error: formatImageSizeError(bytes),
     };
   }
 
@@ -125,11 +129,9 @@ export async function readImageAsBlock(absPath: string): Promise<ReadImageResult
   }
 
   if (bytes > MAX_IMAGE_BYTES) {
-    const mb = (bytes / (1024 * 1024)).toFixed(1);
-    const limit = (MAX_IMAGE_BYTES / (1024 * 1024)).toFixed(2);
     return {
       ok: false,
-      error: `Image too large (${mb} MB > ${limit} MB limit). Resize or compress it before sending.`,
+      error: formatImageSizeError(bytes),
     };
   }
 

--- a/src/tools/imageUtils.ts
+++ b/src/tools/imageUtils.ts
@@ -77,6 +77,33 @@ export type ReadImageResult =
   | { ok: true; block: ImageBlock; bytes: number; mediaType: string }
   | { ok: false; error: string };
 
+export function imageBufferAsBlock(absPath: string, data: Buffer): ReadImageResult {
+  const mediaType = imageMediaType(absPath);
+  if (!mediaType) {
+    return { ok: false, error: `Unsupported image type: ${path.extname(absPath) || "(none)"}` };
+  }
+
+  const bytes = data.byteLength;
+  if (bytes > MAX_IMAGE_BYTES) {
+    const mb = (bytes / (1024 * 1024)).toFixed(1);
+    const limit = (MAX_IMAGE_BYTES / (1024 * 1024)).toFixed(2);
+    return {
+      ok: false,
+      error: `Image too large (${mb} MB > ${limit} MB limit). Resize or compress it before sending.`,
+    };
+  }
+
+  return {
+    ok: true,
+    bytes,
+    mediaType,
+    block: {
+      type: "image",
+      source: { type: "base64", media_type: mediaType, data: data.toString("base64") },
+    },
+  };
+}
+
 /**
  * Read an image file into a base64 `ImageBlock`, enforcing the size guard.
  * The caller is expected to have already resolved/validated the path.
@@ -106,11 +133,6 @@ export async function readImageAsBlock(absPath: string): Promise<ReadImageResult
     };
   }
 
-  const data = await fs.readFile(absPath, { encoding: "base64" });
-  return {
-    ok: true,
-    bytes,
-    mediaType,
-    block: { type: "image", source: { type: "base64", media_type: mediaType, data } },
-  };
+  const data = await fs.readFile(absPath);
+  return imageBufferAsBlock(absPath, data);
 }

--- a/src/tools/multiEditTool.ts
+++ b/src/tools/multiEditTool.ts
@@ -1,6 +1,5 @@
-import * as fs from "node:fs/promises";
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveWorkspacePath } from "./pathUtils.js";
+import { resolveSafePath, updateWorkspaceTextFile } from "./pathUtils.js";
 import {
   applyEditsToContent,
   EditError,
@@ -77,39 +76,22 @@ export const multiEditTool: Tool = {
       };
     }
 
-    let resolvedPath: string;
     try {
-      resolvedPath = resolveWorkspacePath(input.file_path, context.cwd);
-    } catch (error: unknown) {
+      const result = await updateWorkspaceTextFile(input.file_path, context.cwd, (original) => {
+        const edit = applyEditsToContent(original, input.edits);
+        return { content: edit.content, value: edit.totalReplacements };
+      });
+
       return {
-        content: error instanceof Error ? `Error: ${error.message}` : `Error: ${String(error)}`,
-        isError: true,
+        content: `Updated file: ${result.requestedPath} — applied ${input.edits.length} edit(s), ${result.value} replacement(s)`,
       };
-    }
-
-    try {
-      const original = await fs.readFile(resolvedPath, "utf-8");
-
-      let updated: string;
-      let totalReplacements: number;
-      try {
-        const result = applyEditsToContent(original, input.edits);
-        updated = result.content;
-        totalReplacements = result.totalReplacements;
-      } catch (error) {
-        if (error instanceof EditError) {
-          // Atomic: nothing written when any edit fails.
-          return { content: `Error: ${error.message} (no changes written to ${resolvedPath})`, isError: true };
-        }
-        throw error;
+    } catch (error: unknown) {
+      if (error instanceof EditError) {
+        return {
+          content: `Error: ${error.message} (no changes written to ${resolveSafePath(input.file_path, context.cwd)})`,
+          isError: true,
+        };
       }
-
-      await fs.writeFile(resolvedPath, updated, "utf-8");
-
-      return {
-        content: `Updated file: ${resolvedPath} — applied ${input.edits.length} edit(s), ${totalReplacements} replacement(s)`,
-      };
-    } catch (error: unknown) {
       return {
         content: `Error editing file: ${error instanceof Error ? error.message : String(error)}`,
         isError: true,

--- a/src/tools/multiEditTool.ts
+++ b/src/tools/multiEditTool.ts
@@ -1,5 +1,9 @@
 import type { Tool, ToolContext, ToolResult } from "./Tool.js";
-import { resolveSafePath, updateWorkspaceTextFile } from "./pathUtils.js";
+import {
+  resolveSafePath,
+  updateWorkspaceTextFile,
+  WorkspacePathError,
+} from "./pathUtils.js";
 import {
   applyEditsToContent,
   EditError,
@@ -91,6 +95,9 @@ export const multiEditTool: Tool = {
           content: `Error: ${error.message} (no changes written to ${resolveSafePath(input.file_path, context.cwd)})`,
           isError: true,
         };
+      }
+      if (error instanceof WorkspacePathError) {
+        return { content: `Error: ${error.message}`, isError: true };
       }
       return {
         content: `Error editing file: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/tools/pathUtils.ts
+++ b/src/tools/pathUtils.ts
@@ -16,6 +16,18 @@ export class WorkspacePathError extends Error {
   }
 }
 
+export class WorkspaceFileTooLargeError extends Error {
+  readonly code = "EFBIG";
+
+  constructor(
+    readonly actualBytes: number,
+    readonly maxBytes: number,
+  ) {
+    super(`File is too large to read (${actualBytes} bytes > ${maxBytes} byte limit)`);
+    this.name = "WorkspaceFileTooLargeError";
+  }
+}
+
 export interface WorkspacePathResolution {
   requestedPath: string;
   resolvedPath: string;
@@ -44,6 +56,10 @@ export interface WorkspaceWriteResult {
   requestedPath: string;
   resolvedPath: string;
   existed: boolean;
+}
+
+export interface WorkspaceReadOptions {
+  maxFileBytes?: number;
 }
 
 interface CanonicalizedPath {
@@ -263,7 +279,33 @@ export async function withValidatedWorkspacePath<T>(
   }
 }
 
-export async function readWorkspaceEntry(filePath: string, cwd: string): Promise<WorkspaceEntry> {
+export async function withValidatedWorkspaceFile<T>(
+  filePath: string,
+  cwd: string,
+  operation: (
+    handle: FileHandle,
+    resolution: WorkspacePathResolution,
+    stats: Stats,
+  ) => Promise<T>,
+): Promise<T> {
+  const lease = await acquireReadLease(filePath, cwd);
+  try {
+    if (!lease.stats.isFile() || !lease.handle) {
+      throw new WorkspacePathError(`Only regular files can be read: ${filePath}`);
+    }
+    const result = await operation(lease.handle, lease.resolution, lease.stats);
+    await verifyLease(lease);
+    return result;
+  } finally {
+    await lease.handle?.close().catch(() => {});
+  }
+}
+
+export async function readWorkspaceEntry(
+  filePath: string,
+  cwd: string,
+  options: WorkspaceReadOptions = {},
+): Promise<WorkspaceEntry> {
   const lease = await acquireReadLease(filePath, cwd);
   try {
     if (lease.stats.isDirectory()) {
@@ -279,6 +321,12 @@ export async function readWorkspaceEntry(filePath: string, cwd: string): Promise
     }
     if (!lease.stats.isFile()) {
       throw new WorkspacePathError(`Only regular files and directories can be read: ${filePath}`);
+    }
+    if (
+      options.maxFileBytes !== undefined &&
+      lease.stats.size > options.maxFileBytes
+    ) {
+      throw new WorkspaceFileTooLargeError(lease.stats.size, options.maxFileBytes);
     }
     if (!lease.handle) {
       throw new WorkspacePathError(`Could not acquire a stable file handle: ${filePath}`);
@@ -299,8 +347,9 @@ export async function readWorkspaceEntry(filePath: string, cwd: string): Promise
 export async function readWorkspaceFile(
   filePath: string,
   cwd: string,
+  options: WorkspaceReadOptions = {},
 ): Promise<Extract<WorkspaceEntry, { kind: "file" }>> {
-  const entry = await readWorkspaceEntry(filePath, cwd);
+  const entry = await readWorkspaceEntry(filePath, cwd, options);
   if (entry.kind !== "file") {
     const error = new Error(`Path is a directory: ${entry.requestedPath}`) as NodeJS.ErrnoException;
     error.code = "EISDIR";
@@ -367,6 +416,32 @@ async function replaceFileContents(handle: FileHandle, data: Buffer): Promise<vo
   }
 }
 
+async function replaceFileContentsFromHandle(
+  targetHandle: FileHandle,
+  sourceHandle: FileHandle,
+): Promise<void> {
+  await targetHandle.truncate(0);
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  let offset = 0;
+  for (;;) {
+    const { bytesRead } = await sourceHandle.read(buffer, 0, buffer.length, offset);
+    if (bytesRead === 0) return;
+
+    let written = 0;
+    while (written < bytesRead) {
+      const result = await targetHandle.write(
+        buffer,
+        written,
+        bytesRead - written,
+        offset + written,
+      );
+      if (result.bytesWritten === 0) throw new Error("File write made no progress");
+      written += result.bytesWritten;
+    }
+    offset += bytesRead;
+  }
+}
+
 export async function writeWorkspaceFile(
   filePath: string,
   cwd: string,
@@ -377,6 +452,26 @@ export async function writeWorkspaceFile(
   try {
     const data = typeof content === "string" ? Buffer.from(content, "utf8") : content;
     await replaceFileContents(lease.handle!, data);
+    if (options.mode !== undefined) await lease.handle!.chmod(options.mode);
+    return {
+      requestedPath: lease.resolution.requestedPath,
+      resolvedPath: lease.resolution.resolvedPath,
+      existed,
+    };
+  } finally {
+    await lease.handle!.close().catch(() => {});
+  }
+}
+
+export async function writeWorkspaceFileFromHandle(
+  filePath: string,
+  cwd: string,
+  sourceHandle: FileHandle,
+  options: { mode?: number } = {},
+): Promise<WorkspaceWriteResult> {
+  const { lease, existed } = await openWorkspaceFileForWrite(filePath, cwd);
+  try {
+    await replaceFileContentsFromHandle(lease.handle!, sourceHandle);
     if (options.mode !== undefined) await lease.handle!.chmod(options.mode);
     return {
       requestedPath: lease.resolution.requestedPath,
@@ -418,17 +513,34 @@ export async function updateWorkspaceTextFile<T>(
 }
 
 export async function removeWorkspaceFile(filePath: string, cwd: string): Promise<boolean> {
-  const resolution = await resolveWorkspacePathDetails(filePath, cwd, true);
-  if (!resolution.exists) return false;
-  const lease = await acquireReadLease(filePath, cwd);
+  const requestedPath = resolveSafePath(filePath, cwd);
+  const parentPath = path.dirname(requestedPath);
+  const parentLease = await acquireReadLease(parentPath, cwd);
   try {
-    if (!lease.stats.isFile()) {
+    if (!parentLease.stats.isDirectory()) {
+      throw new WorkspacePathError(`Parent path is not a directory: ${parentPath}`);
+    }
+
+    const deletionPath = path.join(
+      parentLease.resolution.resolvedPath,
+      path.basename(requestedPath),
+    );
+    let entryStats: Stats;
+    try {
+      entryStats = await fs.lstat(deletionPath);
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return false;
+      throw error;
+    }
+    if (!entryStats.isFile() && !entryStats.isSymbolicLink()) {
       throw new WorkspacePathError(`Only regular files can be removed: ${filePath}`);
     }
-    await verifyLease(lease);
-    await fs.unlink(lease.resolution.resolvedPath);
+
+    await verifyLease(parentLease);
+    await fs.unlink(deletionPath);
+    await verifyLease(parentLease);
     return true;
   } finally {
-    await lease.handle?.close().catch(() => {});
+    await parentLease.handle?.close().catch(() => {});
   }
 }

--- a/src/tools/pathUtils.ts
+++ b/src/tools/pathUtils.ts
@@ -1,15 +1,65 @@
+import { constants, type Stats } from "node:fs";
+import * as fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
-import { getEasyAgentHome } from "../utils/paths.js";
+import { getPlansRoot } from "../utils/paths.js";
 
-// Extra roots beyond cwd + ~/.easy-agent, from the `additionalDirectories`
-// setting. Resolved to absolute paths and installed once at startup (see
-// cli.ts). Kept module-level so the sync path guards below stay sync — the
-// file tools call them on a hot path and shouldn't await a settings read each
-// time. Trust-gating happens at load time (untrusted project/local dirs are
-// dropped before they reach here).
 let additionalAllowedRoots: string[] = [];
 
-/** Install the resolved `additionalDirectories` (absolute paths). */
+export class WorkspacePathError extends Error {
+  readonly code = "EWORKSPACEBOUNDARY";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspacePathError";
+  }
+}
+
+export interface WorkspacePathResolution {
+  requestedPath: string;
+  resolvedPath: string;
+  declaredRoot: string;
+  canonicalRoot: string;
+  exists: boolean;
+}
+
+export type WorkspaceEntry =
+  | {
+      kind: "file";
+      requestedPath: string;
+      resolvedPath: string;
+      stats: Stats;
+      data: Buffer;
+    }
+  | {
+      kind: "directory";
+      requestedPath: string;
+      resolvedPath: string;
+      stats: Stats;
+      entries: string[];
+    };
+
+export interface WorkspaceWriteResult {
+  requestedPath: string;
+  resolvedPath: string;
+  existed: boolean;
+}
+
+interface CanonicalizedPath {
+  resolvedPath: string;
+  exists: boolean;
+}
+
+interface WorkspacePathLease {
+  resolution: WorkspacePathResolution;
+  stats: Stats;
+  handle?: FileHandle;
+}
+
+const NOFOLLOW_FLAG = constants.O_NOFOLLOW ?? 0;
+const DIRECTORY_FLAG = process.platform === "win32" ? 0 : (constants.O_DIRECTORY ?? 0);
+
 export function setAdditionalAllowedRoots(roots: string[]): void {
   additionalAllowedRoots = roots.map((root) => path.resolve(root));
 }
@@ -21,7 +71,7 @@ export function getAdditionalAllowedRoots(): string[] {
 export function getToolAllowedRoots(cwd: string): string[] {
   return [
     path.resolve(cwd),
-    path.resolve(getEasyAgentHome()),
+    path.resolve(getPlansRoot()),
     ...additionalAllowedRoots,
   ];
 }
@@ -31,31 +81,354 @@ export function describeAllowedRoots(cwd: string): string {
 }
 
 export function expandHome(filePath: string): string {
-  return filePath.startsWith("~")
-    ? filePath.replace("~", process.env.HOME || "")
-    : filePath;
+  if (filePath === "~") return os.homedir();
+  if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
 }
 
 export function resolveSafePath(filePath: string, cwd: string): string {
   return path.resolve(cwd, expandHome(filePath));
 }
 
+function isContained(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 export function ensureInsideAllowedRoots(resolvedPath: string, cwd: string): void {
   const normalizedPath = path.resolve(resolvedPath);
-  for (const root of getToolAllowedRoots(cwd)) {
-    const relative = path.relative(root, normalizedPath);
-    if (relative === "" || relative === ".") return;
-    if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
-      return;
-    }
-  }
-  throw new Error(
+  if (getToolAllowedRoots(cwd).some((root) => isContained(root, normalizedPath))) return;
+  throw new WorkspacePathError(
     `Path is outside the allowed roots: ${resolvedPath}. Allowed roots: ${describeAllowedRoots(cwd)}`,
   );
 }
 
-export function resolveWorkspacePath(filePath: string, cwd: string): string {
-  const resolvedPath = resolveSafePath(filePath, cwd);
-  ensureInsideAllowedRoots(resolvedPath, cwd);
-  return resolvedPath;
+function isErrno(error: unknown, code: string): boolean {
+  return (error as NodeJS.ErrnoException)?.code === code;
+}
+
+async function canonicalizePath(
+  target: string,
+  allowMissing: boolean,
+): Promise<CanonicalizedPath> {
+  try {
+    return { resolvedPath: await fs.realpath(target), exists: true };
+  } catch (error) {
+    if (isErrno(error, "ELOOP")) {
+      throw new WorkspacePathError(`Symbolic-link loop is not allowed: ${target}`);
+    }
+    if (!allowMissing || !isErrno(error, "ENOENT")) throw error;
+  }
+
+  const missingSegments: string[] = [];
+  let current = target;
+
+  for (;;) {
+    try {
+      const currentStats = await fs.lstat(current);
+      if (currentStats.isSymbolicLink()) {
+        throw new WorkspacePathError(`Dangling symbolic link is not allowed: ${current}`);
+      }
+      const real = await fs.realpath(current);
+      return {
+        resolvedPath: path.join(real, ...missingSegments.reverse()),
+        exists: false,
+      };
+    } catch (error) {
+      if (error instanceof WorkspacePathError) throw error;
+      if (isErrno(error, "ELOOP")) {
+        throw new WorkspacePathError(`Symbolic-link loop is not allowed: ${target}`);
+      }
+      if (!isErrno(error, "ENOENT")) throw error;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new WorkspacePathError(`Cannot resolve an existing ancestor for path: ${target}`);
+    }
+    missingSegments.push(path.basename(current));
+    current = parent;
+  }
+}
+
+async function resolveWorkspacePathDetails(
+  filePath: string,
+  cwd: string,
+  allowMissing: boolean,
+): Promise<WorkspacePathResolution> {
+  const requestedPath = resolveSafePath(filePath, cwd);
+  const matchingRoots = getToolAllowedRoots(cwd).filter((root) => isContained(root, requestedPath));
+  if (matchingRoots.length === 0) {
+    throw new WorkspacePathError(
+      `Path is outside the allowed roots: ${requestedPath}. Allowed roots: ${describeAllowedRoots(cwd)}`,
+    );
+  }
+
+  const candidate = await canonicalizePath(requestedPath, allowMissing);
+  for (const declaredRoot of matchingRoots) {
+    let root: CanonicalizedPath;
+    try {
+      root = await canonicalizePath(declaredRoot, true);
+    } catch {
+      continue;
+    }
+    if (isContained(root.resolvedPath, candidate.resolvedPath)) {
+      return {
+        requestedPath,
+        resolvedPath: candidate.resolvedPath,
+        declaredRoot,
+        canonicalRoot: root.resolvedPath,
+        exists: candidate.exists,
+      };
+    }
+  }
+
+  throw new WorkspacePathError(
+    `Path resolves outside the allowed roots: ${requestedPath}. Allowed roots: ${describeAllowedRoots(cwd)}`,
+  );
+}
+
+export async function resolveWorkspacePath(filePath: string, cwd: string): Promise<string> {
+  return (await resolveWorkspacePathDetails(filePath, cwd, false)).resolvedPath;
+}
+
+export async function resolveWorkspacePathForWrite(
+  filePath: string,
+  cwd: string,
+): Promise<WorkspacePathResolution> {
+  return resolveWorkspacePathDetails(filePath, cwd, true);
+}
+
+function sameFile(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function verifyLease(lease: WorkspacePathLease): Promise<void> {
+  const currentRealPath = await fs.realpath(lease.resolution.resolvedPath);
+  if (!isContained(lease.resolution.canonicalRoot, currentRealPath)) {
+    throw new WorkspacePathError(
+      `Path changed to a target outside the allowed root: ${lease.resolution.requestedPath}`,
+    );
+  }
+
+  const currentStats = await fs.stat(currentRealPath);
+  const expectedStats = lease.handle ? await lease.handle.stat() : lease.stats;
+  if (!sameFile(expectedStats, currentStats)) {
+    throw new WorkspacePathError(
+      `Path changed while the operation was in progress: ${lease.resolution.requestedPath}`,
+    );
+  }
+}
+
+async function acquireReadLease(filePath: string, cwd: string): Promise<WorkspacePathLease> {
+  const resolution = await resolveWorkspacePathDetails(filePath, cwd, false);
+  const stats = await fs.stat(resolution.resolvedPath);
+  const flags = constants.O_RDONLY | NOFOLLOW_FLAG | (stats.isDirectory() ? DIRECTORY_FLAG : 0);
+
+  let handle: FileHandle | undefined;
+  try {
+    handle = await fs.open(resolution.resolvedPath, flags);
+  } catch (error) {
+    const canUseWindowsDirectoryFallback =
+      process.platform === "win32" &&
+      stats.isDirectory() &&
+      (isErrno(error, "EISDIR") || isErrno(error, "EPERM"));
+    if (!canUseWindowsDirectoryFallback) throw error;
+  }
+
+  const lease: WorkspacePathLease = { resolution, stats, ...(handle ? { handle } : {}) };
+  try {
+    await verifyLease(lease);
+    return lease;
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    throw error;
+  }
+}
+
+export async function withValidatedWorkspacePath<T>(
+  filePath: string,
+  cwd: string,
+  operation: (resolvedPath: string, stats: Stats) => Promise<T>,
+): Promise<T> {
+  const lease = await acquireReadLease(filePath, cwd);
+  try {
+    const result = await operation(lease.resolution.resolvedPath, lease.stats);
+    await verifyLease(lease);
+    return result;
+  } finally {
+    await lease.handle?.close().catch(() => {});
+  }
+}
+
+export async function readWorkspaceEntry(filePath: string, cwd: string): Promise<WorkspaceEntry> {
+  const lease = await acquireReadLease(filePath, cwd);
+  try {
+    if (lease.stats.isDirectory()) {
+      const entries = await fs.readdir(lease.resolution.resolvedPath);
+      await verifyLease(lease);
+      return {
+        kind: "directory",
+        requestedPath: lease.resolution.requestedPath,
+        resolvedPath: lease.resolution.resolvedPath,
+        stats: lease.stats,
+        entries,
+      };
+    }
+    if (!lease.stats.isFile()) {
+      throw new WorkspacePathError(`Only regular files and directories can be read: ${filePath}`);
+    }
+    if (!lease.handle) {
+      throw new WorkspacePathError(`Could not acquire a stable file handle: ${filePath}`);
+    }
+    const data = await lease.handle.readFile();
+    return {
+      kind: "file",
+      requestedPath: lease.resolution.requestedPath,
+      resolvedPath: lease.resolution.resolvedPath,
+      stats: lease.stats,
+      data,
+    };
+  } finally {
+    await lease.handle?.close().catch(() => {});
+  }
+}
+
+export async function readWorkspaceFile(
+  filePath: string,
+  cwd: string,
+): Promise<Extract<WorkspaceEntry, { kind: "file" }>> {
+  const entry = await readWorkspaceEntry(filePath, cwd);
+  if (entry.kind !== "file") {
+    const error = new Error(`Path is a directory: ${entry.requestedPath}`) as NodeJS.ErrnoException;
+    error.code = "EISDIR";
+    throw error;
+  }
+  return entry;
+}
+
+async function ensureWorkspaceParent(filePath: string, cwd: string): Promise<void> {
+  const requestedPath = resolveSafePath(filePath, cwd);
+  const parent = path.dirname(requestedPath);
+  const parentResolution = await resolveWorkspacePathDetails(parent, cwd, true);
+  await fs.mkdir(parentResolution.resolvedPath, { recursive: true });
+  await resolveWorkspacePathDetails(parent, cwd, false);
+}
+
+async function openWorkspaceFileForWrite(
+  filePath: string,
+  cwd: string,
+): Promise<{ lease: WorkspacePathLease; existed: boolean }> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let resolution = await resolveWorkspacePathDetails(filePath, cwd, true);
+    if (!resolution.exists) {
+      await ensureWorkspaceParent(filePath, cwd);
+      resolution = await resolveWorkspacePathDetails(filePath, cwd, true);
+    }
+
+    const existed = resolution.exists;
+    const flags = existed
+      ? constants.O_WRONLY | NOFOLLOW_FLAG
+      : constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | NOFOLLOW_FLAG;
+
+    let handle: FileHandle;
+    try {
+      handle = await fs.open(resolution.resolvedPath, flags, 0o666);
+    } catch (error) {
+      if (!existed && isErrno(error, "EEXIST") && attempt === 0) continue;
+      throw error;
+    }
+
+    const stats = await handle.stat();
+    const lease: WorkspacePathLease = { resolution, stats, handle };
+    try {
+      await verifyLease(lease);
+      if (!stats.isFile()) {
+        throw new WorkspacePathError(`Only regular files can be written: ${filePath}`);
+      }
+      return { lease, existed };
+    } catch (error) {
+      await handle.close().catch(() => {});
+      throw error;
+    }
+  }
+  throw new WorkspacePathError(`Path changed repeatedly while opening it: ${filePath}`);
+}
+
+async function replaceFileContents(handle: FileHandle, data: Buffer): Promise<void> {
+  await handle.truncate(0);
+  let offset = 0;
+  while (offset < data.length) {
+    const { bytesWritten } = await handle.write(data, offset, data.length - offset, offset);
+    if (bytesWritten === 0) throw new Error("File write made no progress");
+    offset += bytesWritten;
+  }
+}
+
+export async function writeWorkspaceFile(
+  filePath: string,
+  cwd: string,
+  content: string | Buffer,
+  options: { mode?: number } = {},
+): Promise<WorkspaceWriteResult> {
+  const { lease, existed } = await openWorkspaceFileForWrite(filePath, cwd);
+  try {
+    const data = typeof content === "string" ? Buffer.from(content, "utf8") : content;
+    await replaceFileContents(lease.handle!, data);
+    if (options.mode !== undefined) await lease.handle!.chmod(options.mode);
+    return {
+      requestedPath: lease.resolution.requestedPath,
+      resolvedPath: lease.resolution.resolvedPath,
+      existed,
+    };
+  } finally {
+    await lease.handle!.close().catch(() => {});
+  }
+}
+
+export async function updateWorkspaceTextFile<T>(
+  filePath: string,
+  cwd: string,
+  update: (original: string) => { content: string; value: T },
+): Promise<WorkspaceWriteResult & { value: T }> {
+  const resolution = await resolveWorkspacePathDetails(filePath, cwd, false);
+  const handle = await fs.open(resolution.resolvedPath, constants.O_RDWR | NOFOLLOW_FLAG);
+  const stats = await handle.stat();
+  const lease: WorkspacePathLease = { resolution, stats, handle };
+
+  try {
+    await verifyLease(lease);
+    if (!stats.isFile()) {
+      throw new WorkspacePathError(`Only regular files can be edited: ${filePath}`);
+    }
+    const original = (await handle.readFile()).toString("utf8");
+    const next = update(original);
+    await replaceFileContents(handle, Buffer.from(next.content, "utf8"));
+    return {
+      requestedPath: resolution.requestedPath,
+      resolvedPath: resolution.resolvedPath,
+      existed: true,
+      value: next.value,
+    };
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+export async function removeWorkspaceFile(filePath: string, cwd: string): Promise<boolean> {
+  const resolution = await resolveWorkspacePathDetails(filePath, cwd, true);
+  if (!resolution.exists) return false;
+  const lease = await acquireReadLease(filePath, cwd);
+  try {
+    if (!lease.stats.isFile()) {
+      throw new WorkspacePathError(`Only regular files can be removed: ${filePath}`);
+    }
+    await verifyLease(lease);
+    await fs.unlink(lease.resolution.resolvedPath);
+    return true;
+  } finally {
+    await lease.handle?.close().catch(() => {});
+  }
 }

--- a/src/ui/utils/toolCardFormat.ts
+++ b/src/ui/utils/toolCardFormat.ts
@@ -230,6 +230,11 @@ function webSearchStat(result: string): string | undefined {
   return `${n} result${n === 1 ? "" : "s"}`;
 }
 
+/** Skill result → "loaded" once the instruction payload has been returned. */
+function skillStat(result: string): string | undefined {
+  return result.startsWith("Loaded skill ") ? "loaded" : undefined;
+}
+
 /** ListMcpResources result → "N resources". */
 function mcpListStat(result: string): string | undefined {
   if (result.includes("No MCP resources")) return "0 resources";
@@ -313,6 +318,12 @@ export function summarizeTool(
     case "WebSearch": {
       const q = asString(inp.query);
       return { label: "WebSearch", target: q ? `"${q}"` : undefined, stat: result ? webSearchStat(result) : undefined };
+    }
+    case "Skill": {
+      const skill = asString(inp.skill);
+      const args = asString(inp.args);
+      const target = skill ? (args ? `${skill} ${args}` : skill) : undefined;
+      return { label: "Skill", target, stat: result ? skillStat(result) : undefined };
     }
     case "ListMcpResources":
       return { label: "ListMcpResources", target: asString(inp.server) ?? "all servers", stat: result ? mcpListStat(result) : undefined };


### PR DESCRIPTION
## 问题与结果

文件工具原先只检查规范化后的字符串路径。工作区内的符号链接可以指向工作区外，导致 `Read`、`Write`、`Edit`、`MultiEdit`、`Grep`、`Glob` 以及文件历史/回滚绕过访问边界。

本次修改把重复的路径判断收拢到共享路径模块。读取会校验最终目标，写入会校验最近存在的父目录和目标路径中的每一段；文件读写通过已验证的文件描述符完成，并在操作前后核对目标身份。各工具原有的匹配、编辑、输出格式和权限逻辑仍保留在原模块中。

Skill 工具卡同时补齐了专用摘要：执行时显示 Skill 名称和参数，成功加载指令后显示 `loaded` 状态，失败结果不会误报为已加载。

## 主要改动

- 建立共享路径策略，同时执行词法路径和 `realpath` 边界校验；支持尚不存在的写入目标、额外工作目录和本身为符号链接的受信目录。
- 使用 `lstat`、`realpath`、`O_NOFOLLOW`、独占创建和文件描述符身份校验，拒绝悬空链接、链接环、越界链接及最终目标替换。
- `Read`、`Write`、`Edit`、`MultiEdit`、`Grep`、`Glob` 和图片附件统一使用这套策略；目录搜索在完成后再次校验目录身份。
- 文件历史、差异检查和 rewind 使用同一边界。备份和恢复按 64 KiB 分块复制，不把整个文件载入内存；恢复“原本不存在”的路径时只删除该目录项，不跟随替换链接。
- 超大图片在读取内容前按文件大小拒绝，保留原有错误文案和内存上限。
- `Glob` 在没有 ripgrep 时使用 Node 跨平台降级实现，Windows 不再误调用系统 `FIND.EXE`。
- 普通文件工具对 Easy Agent 全局目录的默认访问从整个 `~/.easy-agent` 收窄为 `~/.easy-agent/plans`。
- 新增工作区路径安全文档和独立回归套件，并将其纳入生产门禁。
- 为 Skill 工具卡增加名称、参数和加载状态摘要，并加入统一 UI 生产门禁。

## 兼容性审查

在首次提交后重新逐文件对照旧实现，发现并修复了四项问题：

- rewind 遇到工作区内的替换链接时可能删除链接目标。
- 图片路径会先完整读入内存再执行大小限制。
- 部分边界错误前缀和合法内部链接的 `Glob` 展示路径发生变化。
- Windows 环境未安装 ripgrep 时，原有 `Glob` 降级分支调用 Unix `find`，导致普通文件发现失败。

随后在合并 PR #20 后的基线版本和当前版本上运行同一组正常操作，覆盖 Read、范围读取、Write 新建/覆盖、Edit、MultiEdit 原子失败、Grep、Glob、目录读取和文件历史回滚。规范化临时目录后，两份结构化结果逐字一致。

## 验证

先在旧实现上运行安全回归套件，确认可以稳定复现 17 项失败，包括文件链接读写越界、目录链接搜索越界、悬空链接创建外部文件、链接链越界、全局用户配置暴露，以及文件历史/rewind 修改外部文件。

当前版本通过：

- 正常功能基线差分：无差异
- `npm run test:path-boundary`
- `npm run typecheck`
- `npm run build`
- `npm run verify:production`（51/51）
- `npm run verify:production:platform`（2/2）
- `npm run test:tool-card-format`
- `test-stage31`、`test-stage32` 和文件历史专项测试

回归覆盖普通读写编辑和结果文案、文件模式、文件/目录符号链接、悬空链接、链接链、链接环、额外工作目录、内部合法链接、嵌套写入、并发目标替换、Windows junction/符号链接以及 checkpoint 恢复。

## 兼容性边界

- CLI、配置格式、会话格式、编辑语义和正常工具返回文本保持不变。
- 普通文件工具不再直接访问 `~/.easy-agent` 下的配置、会话等全局状态；计划目录仍可访问。需要操作其他外部目录时，通过受信配置中的 `additionalDirectories` 明确加入。这是本 PR 唯一有意收紧的既有行为。
- 配置、记忆、任务、会话、插件和团队功能通过各自的运行时模块访问内部状态，不依赖普通文件工具，相关生产门禁均已通过。
- Node.js 没有跨平台的 `openat` 路径遍历接口。最终文件操作通过 `O_NOFOLLOW` 和文件描述符身份校验保护；目录搜索遇到运行期间的身份变化会丢弃结果。能够持续改写上级目录结构的同权限进程仍属于操作系统级对手，沙箱继续作为纵深防护。

Closes #4
