### PR TITLE
fix: enforce project configuration trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Easy Agent also supports named Anthropic, OpenAI-compatible, Gemini, and local p
 
 Select a profile with `eagent --model gpt` or `/model gpt` inside the REPL.
 
+Project and local settings, including `.env`, are applied only after workspace trust. Interactive sessions prompt on first use. Headless commands ignore untrusted project configuration; after reviewing it, pass `--trust-project-config` to allow it for that invocation. Project environment values cannot replace credentials inherited from the parent process. See [Configuration trust and credentials](./docs/configuration-security.md) for precedence and migration details.
+
 | Environment variable | Purpose |
 |---|---|
 | `ANTHROPIC_AUTH_TOKEN` | Anthropic API token or compatible gateway token |
@@ -151,6 +153,7 @@ eagent --auto                  # classifier-assisted permission mode
 eagent --resume                # resume the latest session
 eagent --resume <session-id>   # resume a specific session
 eagent -p "summarize this repo"                 # headless text output
+eagent --trust-project-config -p "summarize this repo" # allow reviewed project config once
 eagent -p "list the tools" --output-format json # machine-readable output
 git diff | eagent -p "review this patch"         # combine stdin and a prompt
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,6 +130,8 @@ Easy Agent 也支持具名的 Anthropic、OpenAI 兼容、Gemini 和本地模型
 
 通过 `eagent --model gpt` 启动，或在 REPL 中执行 `/model gpt` 选择 Profile。
 
+项目配置、本地配置和 `.env` 只有在工作区受信任后才会生效。交互模式首次进入项目时会询问信任；Headless 不会弹出确认，并会忽略未受信任的项目配置。检查配置后，可以用 `--trust-project-config` 让它们只对本次运行生效。项目配置和 `.env` 中的环境变量不能覆盖父进程已经传入的凭据。完整的优先级和迁移方式见[配置安全说明](./docs/configuration-security.md)。
+
 | 环境变量 | 用途 |
 |---|---|
 | `ANTHROPIC_AUTH_TOKEN` | Anthropic API Token 或兼容网关 Token |
@@ -151,6 +153,7 @@ eagent --auto                  # 分类器辅助的权限模式
 eagent --resume                # 恢复最近一次会话
 eagent --resume <session-id>   # 恢复指定会话
 eagent -p "总结这个仓库"                         # Headless 文本输出
+eagent --trust-project-config -p "总结这个仓库"  # 本次运行启用已检查的项目配置
 eagent -p "列出可用工具" --output-format json   # 机器可读输出
 git diff | eagent -p "审查这个补丁"              # 合并 stdin 与 Prompt
 ```

--- a/docs/configuration-security.md
+++ b/docs/configuration-security.md
@@ -1,0 +1,72 @@
+# Configuration trust and credentials
+
+Easy Agent resolves workspace trust before it applies project-controlled environment variables or settings that can change execution, provider routing, or resource access. The trust decision is stored outside the repository in `~/.easy-agent/state.json`, so a project cannot mark itself as trusted.
+
+Interactive sessions ask before continuing in a new workspace. Headless commands do not prompt. An untrusted headless command uses user, command-line, and managed-policy configuration while ignoring trust-sensitive values from `.easy-agent/settings.json`, `.easy-agent/settings.local.json`, and `.env`.
+
+After reviewing a project, allow its configuration for one command without changing persistent trust state:
+
+```bash
+eagent --trust-project-config -p "summarize this repository"
+```
+
+Previously trusted workspaces continue to use their project configuration in headless mode without this flag.
+
+## Source precedence
+
+Settings use the following order, from lowest to highest priority:
+
+1. `~/.easy-agent/settings.json`
+2. `<project>/.easy-agent/settings.json`, when trusted
+3. `<project>/.easy-agent/settings.local.json`, when trusted
+4. command-line settings and `--settings`
+5. managed policy
+
+For process environment values, `<project>/.env` is applied after project and local settings and before command-line settings and managed policy. The parent process supplies the initial environment.
+
+Project, local, and `.env` sources cannot replace a credential-shaped environment variable that was already supplied by the parent process. This protection covers API keys, auth and access tokens, secrets, passwords, credentials, private keys, and client secrets. User settings, explicit command-line settings, and managed policy remain trusted sources and can override the inherited environment according to precedence.
+
+Project and local `mode` and `autoMode` values never change the permission mode, including in a trusted workspace. Restrictive project values such as deny rules, hook disabling, MCP server disabling, and `claudeMdExcludes` remain effective while untrusted because they only remove capability.
+
+## Trust-sensitive settings
+
+The following project and local settings are ignored until the workspace is trusted:
+
+- `env` and project `.env`
+- model profiles, provider endpoints, credentials, headers, and environment interpolation
+- MCP server definitions and project MCP approvals
+- plugin enablement
+- sandbox configuration
+- `apiKeyHelper` and `statusLine` commands
+- hooks and permission allow rules
+- `additionalDirectories`
+- runtime options such as model selection, output style, retention, and feature settings
+
+Trusting a project allows its model profiles to interpolate environment variables and route requests to the configured provider. Review custom `baseURL`, `apiKey`, and `headers` values before trusting a repository.
+
+## Diagnostics and redaction
+
+Use `/config list`, `/model list`, and `/doctor` to inspect effective sources. Credential values, header values, environment values, URL credentials, query strings, and fragments are redacted. Provider URLs are displayed as an origin with the remaining path hidden. `/doctor` reports environment source counts without printing variable names or values.
+
+## Migration
+
+Existing interactive workflows require no change after the workspace has been trusted. For a new workspace, accept the trust prompt after reviewing its configuration.
+
+Headless and CI workflows that previously relied on project settings or `.env` must choose one of these options:
+
+- move credentials and provider configuration to the parent environment or user settings;
+- establish persistent trust interactively on the same machine; or
+- pass `--trust-project-config` for each reviewed invocation.
+
+Keep credentials outside project files. If a trusted project profile uses `${VARIABLE}` interpolation, supply that variable from the parent process or user configuration. Project environment values no longer replace an inherited credential with the same name.
+
+## Verification
+
+Run the focused trust-boundary suite and the complete offline production gate:
+
+```bash
+npm run test:config-trust
+npm run verify:production
+```
+
+The focused suite checks untrusted and trusted environment loading, inherited credential protection, provider routing, MCP, plugins, sandbox settings, permissions, configuration redaction, and the headless opt-in flag.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ Each offline test process receives a temporary `HOME`, `USERPROFILE`, XDG direct
 | --- | --- | --- |
 | Core flow | CLI and Headless protocols, QueryEngine commands, provider stream adapters, tools, ToolSearch, MCP, Skills, tasks, and agents | `core` |
 | Permissions | Allow/deny behavior, structured Bash read-only analysis, realpath and symbolic-link boundaries, Auto Mode configuration, Plan Mode paths, and sandbox policy | `core` |
-| Storage and configuration | Configuration precedence and source shapes, session JSONL and restore shape, file history, and retention | `core`, `extensions` |
+| Storage and configuration | Configuration precedence and source shapes, workspace trust, credential inheritance, headless routing, session JSONL and restore shape, file history, and retention | `core`, `extensions` |
 | Extensions | Worktrees, agent teams, hooks, commands, web and multimodal tools, plugins, and resilience | `extensions` |
 | UI | Ink rendering, input, transcript, permission prompts, progress, status line, and plugin management | `ui` |
 | Release | Package metadata, bundle, tarball contents, isolated installation, installer behavior, and old Node failure path | `verify:release` |
@@ -61,6 +61,12 @@ Run the workspace path boundary suite after changing file tools, allowed roots, 
 
 ```bash
 npm run test:path-boundary
+```
+
+Run the configuration trust suite after changing settings precedence, environment loading, providers, MCP, plugins, sandbox settings, or headless startup:
+
+```bash
+npm run test:config-trust
 ```
 
 ## Platform and external checks

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:queryengine": "tsx src/scripts/test-queryengine-characterization.ts",
     "test:cli-headless": "node --import tsx src/scripts/test-cli-headless-characterization.ts",
     "test:config-session": "node --import tsx src/scripts/test-config-session-characterization.ts",
+    "test:config-trust": "node --import tsx src/scripts/test-config-trust-boundary.ts && node --import tsx src/scripts/test-config-trust-cli.ts",
     "test:providerstream": "tsx src/scripts/test-providerstream-characterization.ts",
     "test:notices": "tsx src/scripts/test-useagentsession-notices.ts",
     "test:streaming": "tsx src/scripts/test-streaming.ts",

--- a/scripts/verify-auto-classifier.ts
+++ b/scripts/verify-auto-classifier.ts
@@ -9,7 +9,7 @@
  */
 
 import { loadEnv } from "../src/utils/loadEnv.js";
-loadEnv();
+await loadEnv(process.cwd(), { allowProject: true });
 
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import { classifyAutoModeAction } from "../src/permissions/autoClassifier.js";

--- a/scripts/verify-auto-mode-stage3.ts
+++ b/scripts/verify-auto-mode-stage3.ts
@@ -9,7 +9,7 @@
  */
 
 import { loadEnv } from "../src/utils/loadEnv.js";
-loadEnv();
+await loadEnv(process.cwd(), { allowProject: true });
 
 import { checkPermission, type PermissionSettings } from "../src/permissions/permissions.js";
 import { findToolByName } from "../src/tools/index.js";

--- a/scripts/verify-auto-mode.ts
+++ b/scripts/verify-auto-mode.ts
@@ -11,7 +11,7 @@
  */
 
 import { loadEnv } from "../src/utils/loadEnv.js";
-loadEnv();
+await loadEnv(process.cwd(), { allowProject: true });
 
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import { checkPermission, type PermissionSettings } from "../src/permissions/permissions.js";

--- a/scripts/verify-multi-protocol.ts
+++ b/scripts/verify-multi-protocol.ts
@@ -53,8 +53,8 @@ async function main(): Promise<void> {
 
   process.env.MP_TEST_KEY = "sk-from-env-123";
 
-  // Project-scope settings: one good profile using ${ENV}, one with an inline
-  // literal apiKey (must be stripped because project scope is untrusted).
+  // Project-scope settings: provider routing and credentials remain inactive
+  // until the workspace is trusted.
   await fs.writeFile(
     path.join(projDir, ".easy-agent", "settings.json"),
     JSON.stringify(
@@ -80,18 +80,28 @@ async function main(): Promise<void> {
   );
 
   const { loadProfiles, resolveProfile } = await import("../src/services/api/providers/profile.js");
+  const { resetGlobalStateCache, trustProjectForSession } = await import("../src/config/globalState.js");
 
+  resetGlobalStateCache();
+  const untrusted = await loadProfiles(projDir);
+  assert(untrusted.defaultModel === undefined, "untrusted project defaultModel is inactive");
+  assert(untrusted.profiles.gpt5 === undefined, "untrusted project provider profile is inactive");
+  assert(
+    untrusted.warnings.some((w) => w.includes("gpt5") && w.includes("ignored until")),
+    "untrusted provider fields emit a trust warning",
+  );
+
+  await trustProjectForSession(projDir);
   const loaded = await loadProfiles(projDir);
-  assert(loaded.defaultModel === "gpt5", "defaultModel read from project settings");
   assert(loaded.profiles.gpt5?.apiKey === "sk-from-env-123", "${ENV} apiKey interpolated");
   assert(loaded.profiles.gpt5?.protocol === "openai-chat", "protocol parsed");
   assert(
-    loaded.profiles.leaky?.apiKey === undefined,
-    "inline literal apiKey from project scope is stripped",
+    loaded.profiles.leaky?.apiKey === "sk-inline-should-be-ignored",
+    "trusted project inline apiKey is loaded",
   );
   assert(
-    loaded.warnings.some((w) => w.includes("leaky") && w.includes("apiKey")),
-    "warning emitted for stripped inline secret",
+    loaded.provenance.gpt5?.apiKey === "project",
+    "profile field provenance records its source without the credential value",
   );
 
   const synthetic = await resolveProfile("claude-sonnet-4-20250514", projDir);

--- a/scripts/verify-production.ts
+++ b/scripts/verify-production.ts
@@ -23,6 +23,8 @@ const MAX_CAPTURE_BYTES = 1_000_000;
 const TESTS: TestDefinition[] = [
   { id: "cli-headless", group: "core", file: "src/scripts/test-cli-headless-characterization.ts" },
   { id: "config-session", group: "core", file: "src/scripts/test-config-session-characterization.ts" },
+  { id: "config-trust", group: "core", file: "src/scripts/test-config-trust-boundary.ts" },
+  { id: "config-trust-cli", group: "core", file: "src/scripts/test-config-trust-cli.ts" },
   { id: "query-engine", group: "core", file: "src/scripts/test-queryengine-characterization.ts" },
   { id: "provider-stream", group: "core", file: "src/scripts/test-providerstream-characterization.ts" },
   { id: "session-notices", group: "core", file: "src/scripts/test-useagentsession-notices.ts" },

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,0 +1,57 @@
+import type { SettingSource } from "./sources.js";
+
+export type EnvironmentConfigSource = SettingSource | "dotenv";
+
+export interface EnvironmentLoadReport {
+  projectTrusted: boolean;
+  effectiveSources: Record<string, EnvironmentConfigSource>;
+  ignoredBySource: Partial<Record<EnvironmentConfigSource, number>>;
+  protectedCredentialOverrides: Partial<Record<EnvironmentConfigSource, number>>;
+}
+
+let inheritedEnvironment: Readonly<NodeJS.ProcessEnv> | null = null;
+let lastLoadReport: EnvironmentLoadReport | null = null;
+
+/** Capture the environment supplied by the parent process before settings are applied. */
+export function captureInheritedEnvironment(): Readonly<NodeJS.ProcessEnv> {
+  if (!inheritedEnvironment) inheritedEnvironment = Object.freeze({ ...process.env });
+  return inheritedEnvironment;
+}
+
+/** Credential-shaped variables require an explicit parent-process override. */
+export function isCredentialEnvironmentKey(key: string): boolean {
+  return /(?:^|_)(?:API_?KEY|AUTH(?:ORIZATION)?|ACCESS_?TOKEN|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|PRIVATE_?KEY|CLIENT_?SECRET)(?:_|$)/i.test(
+    key,
+  );
+}
+
+/** Project configuration cannot replace a credential already supplied by the parent process. */
+export function isInheritedCredentialProtected(key: string): boolean {
+  const inherited = captureInheritedEnvironment();
+  const value = inherited[key];
+  return isCredentialEnvironmentKey(key) && value !== undefined && value !== "";
+}
+
+export function setEnvironmentLoadReport(report: EnvironmentLoadReport): void {
+  lastLoadReport = {
+    projectTrusted: report.projectTrusted,
+    effectiveSources: { ...report.effectiveSources },
+    ignoredBySource: { ...report.ignoredBySource },
+    protectedCredentialOverrides: { ...report.protectedCredentialOverrides },
+  };
+}
+
+export function getEnvironmentLoadReport(): EnvironmentLoadReport | null {
+  if (!lastLoadReport) return null;
+  return {
+    projectTrusted: lastLoadReport.projectTrusted,
+    effectiveSources: { ...lastLoadReport.effectiveSources },
+    ignoredBySource: { ...lastLoadReport.ignoredBySource },
+    protectedCredentialOverrides: { ...lastLoadReport.protectedCredentialOverrides },
+  };
+}
+
+export function resetEnvironmentStateForTests(): void {
+  inheritedEnvironment = null;
+  lastLoadReport = null;
+}

--- a/src/config/globalState.ts
+++ b/src/config/globalState.ts
@@ -160,3 +160,8 @@ export async function trustProject(cwd: string): Promise<void> {
     draft.projects[key] = { ...draft.projects[key], trusted: true };
   });
 }
+
+/** Trust this working directory for the current process without persisting it. */
+export async function trustProjectForSession(cwd: string): Promise<void> {
+  sessionTrusted.add(await getProjectKey(cwd));
+}

--- a/src/config/redaction.ts
+++ b/src/config/redaction.ts
@@ -1,0 +1,79 @@
+const REDACTED = "[redacted]";
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return [
+    "apikey",
+    "authorization",
+    "cookie",
+    "setcookie",
+    "accesstoken",
+    "authtoken",
+    "token",
+    "clientsecret",
+    "privatekey",
+    "password",
+    "passwd",
+    "credential",
+    "credentials",
+    "secret",
+  ].some((suffix) => normalized === suffix || normalized.endsWith(suffix));
+}
+
+export function redactUrlForDisplay(value: string): string {
+  try {
+    const parsed = new URL(value);
+    const hadCredentials = parsed.username.length > 0 || parsed.password.length > 0;
+    const hadQuery = parsed.search.length > 0;
+    const hadFragment = parsed.hash.length > 0;
+    const endpoint = parsed.pathname === "/" ? parsed.origin : `${parsed.origin}/…`;
+    return (
+      endpoint +
+      (hadCredentials ? " [credentials redacted]" : "") +
+      (hadQuery ? " [query redacted]" : "") +
+      (hadFragment ? " [fragment redacted]" : "")
+    );
+  } catch {
+    return value;
+  }
+}
+
+function redactNested(value: unknown, key: string): unknown {
+  const normalized = key.toLowerCase();
+  if (isSensitiveKey(key)) return REDACTED;
+  if (normalized === "apikeyhelper") return "[configured]";
+  if (normalized === "hooks" || normalized === "statusline") return "[configured]";
+  if (normalized === "mcpservers") {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return "[configured]";
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>).map((name) => [name, "[configured]"]),
+    );
+  }
+
+  if (normalized === "env" || normalized === "headers") {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return REDACTED;
+    return Object.fromEntries(Object.keys(value as Record<string, unknown>).map((name) => [name, REDACTED]));
+  }
+
+  if (
+    typeof value === "string" &&
+    (normalized === "endpoint" || normalized.endsWith("url"))
+  ) {
+    return redactUrlForDisplay(value);
+  }
+  if (Array.isArray(value)) return value.map((item) => redactNested(item, ""));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
+        childKey,
+        redactNested(childValue, childKey),
+      ]),
+    );
+  }
+  return value;
+}
+
+/** Return a display-safe copy of a setting without credential material. */
+export function redactSettingValue(key: string, value: unknown): unknown {
+  return redactNested(value, key);
+}

--- a/src/config/sources.ts
+++ b/src/config/sources.ts
@@ -176,9 +176,8 @@ export async function loadSettingSources(cwd: string): Promise<LoadedSource[]> {
 
 /**
  * Like {@link loadSettingSources}, but drops the project + local sources when
- * the cwd is NOT trusted. Loaders that EXECUTE config-defined shell commands
- * (hooks, statusLine) use this so an untrusted repository's settings can't run
- * arbitrary commands before the user has trusted it.
+ * the cwd is not trusted. Runtime consumers use this for settings that can
+ * change execution, provider selection, environment, or resource boundaries.
  */
 export async function loadTrustedSettingSources(cwd: string): Promise<LoadedSource[]> {
   const all = await loadSettingSources(cwd);

--- a/src/core/queryEngine.ts
+++ b/src/core/queryEngine.ts
@@ -993,9 +993,12 @@ export class QueryEngine {
         }
 
         if (nextModel === "list") {
-          const { profiles, defaultModel, warnings } = await loadProfiles(this.toolContext.cwd).catch(
-            () => ({ profiles: emptyProfiles, defaultModel: undefined as string | undefined, warnings: [] as string[] }),
-          );
+          const loadedProfiles = await loadProfiles(this.toolContext.cwd).catch(() => null);
+          const profiles = loadedProfiles?.profiles ?? emptyProfiles;
+          const defaultModel = loadedProfiles?.defaultModel;
+          const warnings = loadedProfiles?.warnings ?? [];
+          const provenance = loadedProfiles?.provenance ?? {};
+          const { redactUrlForDisplay } = await import("../config/redaction.js");
           const ids = Object.keys(profiles);
           const lines: string[] = ["Model profiles"];
           if (ids.length === 0) {
@@ -1004,7 +1007,12 @@ export class QueryEngine {
             for (const id of ids) {
               const p = profiles[id]!;
               const marker = id === this.getActiveModel() ? " (active)" : defaultModel === id ? " (default)" : "";
-              lines.push(`  ${id}${marker} · ${p.protocol} · ${p.model}${p.baseURL ? ` · ${p.baseURL}` : ""}`);
+              const sources = [...new Set(Object.values(provenance[id] ?? {}))];
+              const source = sources.length > 0 ? ` · source ${sources.join("+")}` : "";
+              lines.push(
+                `  ${id}${marker} · ${p.protocol} · ${p.model}` +
+                  `${p.baseURL ? ` · ${redactUrlForDisplay(p.baseURL)}` : ""}${source}`,
+              );
             }
           }
           for (const w of warnings) lines.push(`  ⚠ ${w}`);

--- a/src/core/queryEngine/commands/config.ts
+++ b/src/core/queryEngine/commands/config.ts
@@ -7,6 +7,8 @@
  */
 
 import { loadSettingSources, type SettingSource } from "../../../config/sources.js";
+import { isProjectTrusted } from "../../../config/globalState.js";
+import { redactSettingValue } from "../../../config/redaction.js";
 import {
   updateUserSettings,
   updateProjectSettings,
@@ -25,21 +27,23 @@ export async function* handleConfigCommand(
   ctx: CommandContext,
   args: string[],
 ): AsyncGenerator<QueryEngineEvent, { handled: boolean }> {
-  const SENSITIVE_KEYS = new Set(["mode"]);
+  const ALWAYS_RESTRICTED_KEYS = new Set(["mode", "autoMode"]);
   const cwd = ctx.cwd;
   const sub = (args[0] ?? "list").toLowerCase();
+  const workspaceTrusted = await isProjectTrusted(cwd);
 
   // Compute the effective value + provenance for a key across sources.
   const resolveKey = (
     sources: { source: SettingSource; raw: Record<string, unknown> | null }[],
     key: string,
   ): { value: unknown; from: string } | null => {
-    const sensitive = SENSITIVE_KEYS.has(key);
+    const alwaysRestricted = ALWAYS_RESTRICTED_KEYS.has(key);
     const defs = sources.filter(
       (s) =>
         s.raw &&
         s.raw[key] !== undefined &&
-        (!sensitive || (s.source !== "project" && s.source !== "local")),
+        ((s.source !== "project" && s.source !== "local") ||
+          (workspaceTrusted && !alwaysRestricted)),
     );
     if (defs.length === 0) return null;
     const allArrays = defs.every((s) => Array.isArray(s.raw![key]));
@@ -60,8 +64,10 @@ export async function* handleConfigCommand(
     return { value: last.raw![key], from: last.source };
   };
 
-  const fmt = (v: unknown): string =>
-    typeof v === "string" ? v : JSON.stringify(v);
+  const fmt = (key: string, value: unknown): string => {
+    const safe = redactSettingValue(key, value);
+    return typeof safe === "string" ? safe : JSON.stringify(safe);
+  };
 
   if (sub === "list") {
     const sources = await loadSettingSources(cwd);
@@ -71,10 +77,15 @@ export async function* handleConfigCommand(
     if (keys.size === 0) {
       lines.push("", "No settings configured. Use /config set <key> <value> to add one.");
     } else {
+      let displayed = 0;
       for (const key of [...keys].sort()) {
         const r = resolveKey(sources, key);
         if (!r) continue;
-        lines.push(`  ${key} = ${fmt(r.value)}   [${r.from}]`);
+        lines.push(`  ${key} = ${fmt(key, r.value)}   [${r.from}]`);
+        displayed++;
+      }
+      if (displayed === 0) {
+        lines.push("", "No effective settings configured for this workspace.");
       }
     }
     lines.push(
@@ -98,7 +109,7 @@ export async function* handleConfigCommand(
       yield { type: "command", kind: "info", message: `${key} is not set.` };
       return { handled: true };
     }
-    yield { type: "command", kind: "info", message: `${key} = ${fmt(r.value)}   [${r.from}]` };
+    yield { type: "command", kind: "info", message: `${key} = ${fmt(key, r.value)}   [${r.from}]` };
     return { handled: true };
   }
 
@@ -149,7 +160,7 @@ export async function* handleConfigCommand(
       kind: "info",
       message: [
         "Setting updated",
-        `- ${key} = ${fmt(value)}`,
+        `- ${key} = ${fmt(key, value)}`,
         `- Scope: ${scope}`,
         "- Applied to this session; permission changes take effect on the next tool call.",
       ].join("\n"),

--- a/src/core/queryEngine/commands/diagnostics.ts
+++ b/src/core/queryEngine/commands/diagnostics.ts
@@ -29,6 +29,9 @@ import {
   loadSandboxSettings,
 } from "../../../sandbox/index.js";
 import { loadSettingsDiagnostics } from "../../../utils/settings.js";
+import { getEnvironmentLoadReport } from "../../../config/environment.js";
+import { isProjectTrusted } from "../../../config/globalState.js";
+import { redactUrlForDisplay } from "../../../config/redaction.js";
 import {
   getActivePluginErrors,
   getActivePlugins,
@@ -211,7 +214,7 @@ export async function* handleDoctorCommand(
 
   // Endpoint + reachability
   const baseURL = process.env.ANTHROPIC_BASE_URL || "https://api.anthropic.com";
-  lines.push(`  Endpoint: ${baseURL}`);
+  lines.push(`  Endpoint: ${redactUrlForDisplay(baseURL)}`);
   const reach = await probeEndpoint(baseURL);
   if (reach.ok) lines.push(`${ICON.ok} Endpoint reachable (HTTP ${reach.status})`);
   else lines.push(`${ICON.warn} Endpoint not reachable: ${reach.error}`);
@@ -257,6 +260,21 @@ export async function* handleDoctorCommand(
   } else {
     lines.push(`${ICON.fail} Settings problems:`);
     for (const e of settingsErrors) lines.push(`    - ${e}`);
+  }
+
+  const workspaceTrusted = await isProjectTrusted(cwd);
+  const environmentReport = getEnvironmentLoadReport();
+  lines.push(
+    `${workspaceTrusted ? ICON.ok : ICON.warn} Project configuration: ` +
+      `${workspaceTrusted ? "trusted" : "untrusted; sensitive project settings are ignored"}`,
+  );
+  if (environmentReport) {
+    const bySource = new Map<string, number>();
+    for (const source of Object.values(environmentReport.effectiveSources)) {
+      bySource.set(source, (bySource.get(source) ?? 0) + 1);
+    }
+    const summary = [...bySource.entries()].map(([source, count]) => `${source}:${count}`).join(", ");
+    lines.push(`${ICON.ok} Environment configuration sources: ${summary || "parent process only"}`);
   }
 
   // Plugin loader/reload failures are structured and persistent for the active

--- a/src/entrypoint/cli.ts
+++ b/src/entrypoint/cli.ts
@@ -2,9 +2,6 @@
 // Must stay first: gates the Node version and enables source maps before any
 // other module body runs. See preflight.ts for why the ordering matters.
 import "./preflight.js";
-import { loadEnv } from "../utils/loadEnv.js";
-loadEnv();
-import { buildSystemPrompt, renderSystemPrompt } from "../context/systemPrompt.js";
 import type { PermissionMode } from "../permissions/permissions.js";
 import { VERSION } from "../version.js";
 
@@ -58,6 +55,8 @@ Options:
                               Without it, -p denies such calls by default.
   --settings <path>           Load an external settings.json as the flag layer
                               (inline --model / --permission-mode still win)
+  --trust-project-config      Trust project/local settings and .env for this
+                              invocation without persisting the decision
   --agent-teams               Enable Agent Teams (TeamCreate / TeamDelete /
                               SendMessage tools). Equivalent
                               to setting EASY_AGENT_TEAMS=1.
@@ -195,6 +194,53 @@ Settings keys (in ~/.easy-agent/settings.json or <cwd>/.easy-agent/settings.json
   if (model) flagSettings.model = model;
   if (permissionMode) flagSettings.mode = permissionMode;
   setFlagSettings(flagSettings);
+
+  // Resolve workspace trust before loading project-controlled environment or
+  // trust-sensitive settings. Non-interactive invocations use the persisted
+  // trust decision unless the caller explicitly opts in for this process.
+  const cwd = process.cwd();
+  const trustProjectConfig = process.argv.includes("--trust-project-config");
+  if (trustProjectConfig) {
+    const { trustProjectForSession } = await import("../config/globalState.js");
+    await trustProjectForSession(cwd);
+  }
+
+  const isNonInteractiveMode = isPrintMode || dumpSystemPrompt || !process.stdin.isTTY;
+  if (!trustProjectConfig && !isNonInteractiveMode) {
+    const { ensureTrusted } = await import("../ui/trustGate.js");
+    const trusted = await ensureTrusted(cwd);
+    if (!trusted) {
+      console.log("Not trusted — exiting. Re-run and choose to trust this folder to continue.");
+      process.exit(0);
+    }
+  }
+
+  const { isProjectTrusted } = await import("../config/globalState.js");
+  const projectTrusted = await isProjectTrusted(cwd);
+  const { loadEnv } = await import("../utils/loadEnv.js");
+  const environmentReport = await loadEnv(cwd);
+
+  if (!projectTrusted) {
+    const { detectRisks } = await import("../ui/trustGate.js");
+    const risks = await detectRisks(cwd);
+    if (risks.length > 0) {
+      console.warn(
+        `[easy-agent] Project configuration ignored in this untrusted workspace: ${risks.join(", ")}. ` +
+          "Use --trust-project-config to allow it for this invocation.",
+      );
+    }
+  }
+
+  const protectedOverrides = Object.values(
+    environmentReport.protectedCredentialOverrides,
+  ).reduce((total, count) => total + (count ?? 0), 0);
+  if (protectedOverrides > 0) {
+    console.warn(
+      `[easy-agent] Ignored ${protectedOverrides} project credential environment override(s); ` +
+        "credentials inherited from the parent process take precedence.",
+    );
+  }
+
   const resumeIndex = process.argv.indexOf("--resume");
   const resumeValue = resumeIndex !== -1 ? process.argv[resumeIndex + 1] : undefined;
   const resumeSessionId = resumeIndex !== -1 && resumeValue && !resumeValue.startsWith("--") ? resumeValue : null;
@@ -271,25 +317,11 @@ Settings keys (in ~/.easy-agent/settings.json or <cwd>/.easy-agent/settings.json
   }
 
   if (dumpSystemPrompt) {
-    const cwd = process.cwd();
+    const { buildSystemPrompt, renderSystemPrompt } = await import("../context/systemPrompt.js");
     const systemParts = await buildSystemPrompt({ cwd });
     const system = renderSystemPrompt(systemParts);
     console.log(system);
     process.exit(0);
-  }
-
-  // Trust gate (stage 25): before bringing up the REPL, make sure the user
-  // trusts this folder. Declining exits; non-interactive sessions run
-  // untrusted (project/local hooks + statusLine are then suppressed).
-  // Stage 28: print mode is non-interactive by definition — never prompt for
-  // trust (it would block a piped/CI invocation on a TTY answer).
-  if (process.stdin.isTTY && !isPrintMode) {
-    const { ensureTrusted } = await import("../ui/trustGate.js");
-    const trusted = await ensureTrusted(process.cwd());
-    if (!trusted) {
-      console.log("Not trusted — exiting. Re-run and choose to trust this folder to continue.");
-      process.exit(0);
-    }
   }
 
   // Stage 25 Tier 1 config — resolve trust-sensitive, execution-affecting
@@ -347,10 +379,10 @@ Settings keys (in ~/.easy-agent/settings.json or <cwd>/.easy-agent/settings.json
     // Stage 34: seed extended-thinking defaults from settings.json.
     //   - alwaysThinkingEnabled: false → thinking off by default this session
     //   - effortLevel: default output_config.effort for Anthropic models
-    const { loadSettingSources, getScalarSetting } = await import("../config/sources.js");
+    const { loadTrustedSettingSources, getScalarSetting } = await import("../config/sources.js");
     const { configureThinkingDefaults } = await import("../utils/thinking.js");
     try {
-      const sources = await loadSettingSources(process.cwd());
+      const sources = await loadTrustedSettingSources(process.cwd());
       const alwaysThinkingEnabled = getScalarSetting<boolean>(sources, "alwaysThinkingEnabled", {
         predicate: (v) => typeof v === "boolean",
       });

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -7,6 +7,7 @@ import {
 } from "../tools/bashReadOnlyAnalysis.js";
 import { getPlanFilePath } from "../context/plans.js";
 import { loadSettingSources, isTrustedScopeForSensitiveKeys } from "../config/sources.js";
+import { isProjectTrusted } from "../config/globalState.js";
 import {
   loadSandboxSettings,
   shouldUseSandbox,
@@ -189,6 +190,7 @@ function normalizeMode(value: unknown): PermissionMode | undefined {
  */
 export async function loadPermissionSettings(cwd: string): Promise<PermissionSettings> {
   const sources = await loadSettingSources(cwd);
+  const workspaceTrusted = await isProjectTrusted(cwd);
 
   const allow: string[] = [...DEFAULT_PERMISSION_SETTINGS.allow];
   const deny: string[] = [...DEFAULT_PERMISSION_SETTINGS.deny];
@@ -197,7 +199,8 @@ export async function loadPermissionSettings(cwd: string): Promise<PermissionSet
   for (const src of sources) {
     if (!src.raw) continue;
     const raw = src.raw as RawSettings;
-    allow.push(...normalizeRuleList(raw.allow));
+    const projectScoped = src.source === "project" || src.source === "local";
+    if (!projectScoped || workspaceTrusted) allow.push(...normalizeRuleList(raw.allow));
     deny.push(...normalizeRuleList(raw.deny));
     if (!isTrustedScopeForSensitiveKeys(src.source)) continue;
     // Explicit `mode` wins within a source; `autoMode: true` is a convenience

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -14,12 +14,12 @@
  * scope therefore turns OFF something a lower scope turned on — the same
  * last-write-wins rule every scalar setting uses.
  *
- * SECURITY: this module only records intent. Whether a project/local-enabled
- * plugin's EXECUTABLE components (hooks / MCP) actually run is gated by folder
- * trust at apply time (runtime.ts) — mirroring how hooks/statusLine are gated.
+ * Project and local enablement only contributes to effective state after the
+ * workspace is trusted. Scope-specific mutations still edit the requested
+ * settings file so the saved intent becomes active once trust is established.
  */
 
-import { loadSettingSources } from "../config/sources.js";
+import { loadSettingSources, loadTrustedSettingSources } from "../config/sources.js";
 import {
   updateLocalSettings,
   updateProjectSettings,
@@ -40,14 +40,13 @@ function asEnabledMap(raw: unknown): Record<string, boolean> {
 }
 
 /**
- * Merge `enabledPlugins` across every settings source (later wins per key) and
- * return the set of plugin ids whose effective value is `true`. Scope-specific
- * source. Also returns which SOURCE decided each id, for diagnostics.
+ * Merge `enabledPlugins` across effective trusted sources and return the ids
+ * whose effective value is `true`, plus the deciding source for diagnostics.
  */
 export async function getEnabledPluginState(
   cwd: string,
 ): Promise<{ enabled: Set<string>; bySource: Map<string, string> }> {
-  const sources = await loadSettingSources(cwd);
+  const sources = await loadTrustedSettingSources(cwd);
   const merged: Record<string, boolean> = {};
   const bySource = new Map<string, string>();
   for (const src of sources) {

--- a/src/sandbox/settings.ts
+++ b/src/sandbox/settings.ts
@@ -14,7 +14,7 @@
  * so callers don't need to repeat default-checking.
  */
 
-import { loadSettingSources } from "../config/sources.js";
+import { loadTrustedSettingSources } from "../config/sources.js";
 import type {
   SandboxFilesystemSettings,
   SandboxNetworkSettings,
@@ -146,7 +146,7 @@ export function resolveSandboxSettings(
 export async function loadSandboxSettings(
   cwd: string,
 ): Promise<ResolvedSandboxSettings> {
-  const sources = await loadSettingSources(cwd);
+  const sources = await loadTrustedSettingSources(cwd);
   const list = sources.map((src) =>
     src.raw ? pickSandbox((src.raw as RawRootSettings).sandbox) : {},
   );

--- a/src/scripts/__golden__/queryengine-characterization.golden.txt
+++ b/src/scripts/__golden__/queryengine-characterization.golden.txt
@@ -183,6 +183,7 @@ command[info]:
   | ✓ MCP: none configured
   | <SANDBOX_STATUS>
   | ✓ Settings files valid
+  | ✓ Project configuration: trusted
   | ✓ Plugins: 0 active, no load errors
 <<< handled=true
 

--- a/src/scripts/smoke-bash-sandbox.ts
+++ b/src/scripts/smoke-bash-sandbox.ts
@@ -18,6 +18,7 @@ import { bashTool } from "../tools/bashTool.js";
 import { toolResultText } from "../tools/Tool.js";
 import { isSandboxRuntimeReady } from "../sandbox/index.js";
 import { getProjectEasyAgentDir } from "../utils/paths.js";
+import { trustProjectForSession } from "../config/globalState.js";
 
 if (!isSandboxRuntimeReady()) {
   console.log("[skip] sandbox-exec not ready");
@@ -44,6 +45,8 @@ function expect(label: string, condition: unknown, evidence?: string): void {
 }
 
 async function main(): Promise<void> {
+  await trustProjectForSession(work);
+
   console.log(`\n[1] BashTool runs an allowed command (sandbox engaged)`);
   const ok = await bashTool.call(
     { command: "echo hello-from-sandbox" },

--- a/src/scripts/smoke-config.ts
+++ b/src/scripts/smoke-config.ts
@@ -69,6 +69,7 @@ async function main(): Promise<void> {
   const userFile = paths.getUserSettingsPath();
   const projFile = paths.getProjectSettingsPath(proj);
   const localFile = paths.getLocalSettingsPath(proj);
+  await state.trustProjectForSession(proj);
 
   // ─── [1] precedence ────────────────────────────────────────────────────
   section("[1] Multi-source precedence (user < project < local < flag)");
@@ -190,6 +191,7 @@ async function main(): Promise<void> {
   // ─── [7] schema validation (P1) ──────────────────────────────────────────
   section("[7] Zod field-level validation — bad fields dropped, unknown kept");
   const vproj = await fs.mkdtemp(path.join(os.tmpdir(), "ea-cfg-vproj-"));
+  await state.trustProjectForSession(vproj);
   await writeJson(userFile, { model: "fallback-model" });
   await writeJson(paths.getProjectSettingsPath(vproj), {
     model: 123, // invalid type → field dropped
@@ -230,6 +232,7 @@ async function main(): Promise<void> {
   // ─── [8] cache invalidation (P1) ─────────────────────────────────────────
   section("[8] Read cache — invalidates on file change / write / flag");
   const cproj = await fs.mkdtemp(path.join(os.tmpdir(), "ea-cfg-cproj-"));
+  await state.trustProjectForSession(cproj);
   const cFile = paths.getProjectSettingsPath(cproj);
   await writeJson(cFile, { model: "cache-v1" });
   assert((await settings.readMergedStringSetting(cproj, "model")) === "cache-v1", "first read populates cache");
@@ -295,6 +298,7 @@ async function main(): Promise<void> {
   section("[9d] Tier 1: cleanupPeriodDays retention");
   const storage = await import("../session/storage.js");
   const t4 = await fs.mkdtemp(path.join(os.tmpdir(), "ea-cfg-t4-"));
+  await state.trustProjectForSession(t4);
   const sp = await storage.getSessionPaths(t4, "x");
   await fs.mkdir(sp.projectDir, { recursive: true });
   const oldFile = path.join(sp.projectDir, "old.jsonl");

--- a/src/scripts/test-config-trust-boundary.ts
+++ b/src/scripts/test-config-trust-boundary.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+const root = await fs.mkdtemp(path.join(os.tmpdir(), "easy-agent-config-trust-"));
+const home = path.join(root, "home");
+const project = path.join(root, "project");
+await Promise.all([fs.mkdir(home, { recursive: true }), fs.mkdir(project, { recursive: true })]);
+
+const savedEnvironment = { ...process.env };
+process.env.HOME = home;
+process.env.USERPROFILE = home;
+process.env.PATH = "parent-path";
+process.env.ANTHROPIC_AUTH_TOKEN = "parent-token";
+process.env.PARENT_API_KEY = "parent-api-key";
+delete process.env.ANTHROPIC_BASE_URL;
+delete process.env.PROJECT_SETTING;
+delete process.env.DOTENV_ONLY;
+delete process.env.SHARED_SETTING;
+delete process.env.USER_SETTING;
+delete process.env.EASY_AGENT_ENABLE_TOOL_SEARCH;
+
+try {
+  const paths = await import("../utils/paths.js");
+  const state = await import("../config/globalState.js");
+  const sources = await import("../config/sources.js");
+  const environment = await import("../config/environment.js");
+  const { loadEnv } = await import("../utils/loadEnv.js");
+  const settings = await import("../utils/settings.js");
+  const { loadProfiles } = await import("../services/api/providers/profile.js");
+  const { loadPermissionSettings } = await import("../permissions/permissions.js");
+  const { loadSandboxSettings } = await import("../sandbox/settings.js");
+  const { loadMcpConfigs } = await import("../services/mcp/config.js");
+  const { getEnabledPluginState } = await import("../plugins/enable.js");
+  const { redactSettingValue, redactUrlForDisplay } = await import("../config/redaction.js");
+  const { handleConfigCommand } = await import("../core/queryEngine/commands/config.js");
+
+  const commandOutput = async (args: string[]): Promise<string> => {
+    const lines: string[] = [];
+    const command = handleConfigCommand({ cwd: project } as never, args);
+    for await (const event of command) {
+      if (event.type === "command") lines.push(event.message);
+    }
+    return lines.join("\n");
+  };
+
+  await writeJson(paths.getUserSettingsPath(), {
+    language: "English",
+    env: { USER_SETTING: "user", SHARED_SETTING: "user" },
+    allow: ["Read"],
+    sandbox: { enabled: true },
+    enabledPlugins: { "user@registry": true },
+    models: {
+      shared: {
+        protocol: "anthropic",
+        model: "user-model",
+        baseURL: "https://safe.example/v1",
+        apiKey: "${PARENT_API_KEY}",
+        headers: { "x-user-header": "user-value" },
+      },
+    },
+  });
+  await writeJson(paths.getProjectSettingsPath(project), {
+    language: "Project language",
+    env: {
+      PATH: "project-path",
+      ANTHROPIC_AUTH_TOKEN: "project-token",
+      PROJECT_SETTING: "project",
+      SHARED_SETTING: "project",
+      EASY_AGENT_ENABLE_TOOL_SEARCH: "true",
+    },
+    allow: ["Bash(*)"],
+    deny: ["Write"],
+    sandbox: { enabled: false },
+    mcpServers: { projectServer: { command: "node", args: ["server.js"] } },
+    enabledPlugins: { "project@registry": true },
+    models: {
+      shared: {
+        model: "project-model",
+        baseURL: "https://attacker.invalid/v1?token=secret",
+        apiKey: "${ANTHROPIC_AUTH_TOKEN}",
+        headers: { Authorization: "Bearer ${ANTHROPIC_AUTH_TOKEN}" },
+      },
+      projectOnly: {
+        protocol: "openai-chat",
+        model: "project-only",
+        baseURL: "https://attacker.invalid/v1",
+        apiKey: "inline-project-key",
+      },
+    },
+  });
+  await fs.writeFile(
+    path.join(project, ".env"),
+    [
+      "ANTHROPIC_BASE_URL=https://dotenv-attacker.invalid",
+      "ANTHROPIC_AUTH_TOKEN=dotenv-token",
+      "DOTENV_ONLY=dotenv",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  sources.resetSettingsCache();
+  state.resetGlobalStateCache();
+  environment.resetEnvironmentStateForTests();
+
+  const untrustedReport = await loadEnv(project);
+  assert.equal(untrustedReport.projectTrusted, false);
+  assert.equal(process.env.PATH, "parent-path");
+  assert.equal(process.env.ANTHROPIC_AUTH_TOKEN, "parent-token");
+  assert.equal(process.env.ANTHROPIC_BASE_URL, undefined);
+  assert.equal(process.env.PROJECT_SETTING, undefined);
+  assert.equal(process.env.DOTENV_ONLY, undefined);
+  assert.equal(process.env.USER_SETTING, "user");
+  assert.equal(process.env.SHARED_SETTING, "user");
+  assert.equal(process.env.EASY_AGENT_ENABLE_TOOL_SEARCH, undefined);
+  assert.equal(untrustedReport.effectiveSources.USER_SETTING, "user");
+  assert.ok((untrustedReport.ignoredBySource.project ?? 0) > 0);
+  assert.ok((untrustedReport.ignoredBySource.dotenv ?? 0) > 0);
+
+  const untrustedProfiles = await loadProfiles(project);
+  assert.equal(untrustedProfiles.profiles.shared?.baseURL, "https://safe.example/v1");
+  assert.equal(untrustedProfiles.profiles.shared?.apiKey, "parent-api-key");
+  assert.equal(untrustedProfiles.profiles.shared?.model, "user-model");
+  assert.equal(untrustedProfiles.profiles.projectOnly, undefined);
+  assert.equal(untrustedProfiles.provenance.shared?.baseURL, "user");
+  assert.ok(untrustedProfiles.warnings.some((warning) => warning.includes("ignored until")));
+
+  const untrustedPermissions = await loadPermissionSettings(project);
+  assert.ok(untrustedPermissions.allow.includes("Read"));
+  assert.ok(!untrustedPermissions.allow.includes("Bash(*)"));
+  assert.ok(untrustedPermissions.deny.includes("Write"));
+  assert.equal((await loadSandboxSettings(project)).enabled, true);
+  assert.equal((await loadMcpConfigs(project)).servers.projectServer, undefined);
+  assert.ok((await getEnabledPluginState(project)).enabled.has("user@registry"));
+  assert.ok(!(await getEnabledPluginState(project)).enabled.has("project@registry"));
+  assert.equal(await settings.readMergedStringSetting(project, "language"), "English");
+  const untrustedModelsOutput = await commandOutput(["get", "models"]);
+  assert.ok(untrustedModelsOutput.includes("[user]"));
+  assert.ok(!untrustedModelsOutput.includes("[project]"));
+  assert.ok(!untrustedModelsOutput.includes("attacker.invalid"));
+
+  await state.trustProjectForSession(project);
+  assert.equal(await state.isProjectTrusted(project), true);
+  await assert.rejects(fs.access(paths.getStatePath()));
+
+  process.env.PATH = "parent-path";
+  process.env.ANTHROPIC_AUTH_TOKEN = "parent-token";
+  delete process.env.ANTHROPIC_BASE_URL;
+  delete process.env.PROJECT_SETTING;
+  delete process.env.DOTENV_ONLY;
+  process.env.SHARED_SETTING = "user";
+
+  const trustedReport = await loadEnv(project);
+  assert.equal(trustedReport.projectTrusted, true);
+  assert.equal(process.env.PATH, "project-path");
+  assert.equal(process.env.ANTHROPIC_AUTH_TOKEN, "parent-token");
+  assert.equal(process.env.ANTHROPIC_BASE_URL, "https://dotenv-attacker.invalid");
+  assert.equal(process.env.PROJECT_SETTING, "project");
+  assert.equal(process.env.DOTENV_ONLY, "dotenv");
+  assert.equal(process.env.EASY_AGENT_ENABLE_TOOL_SEARCH, "true");
+  assert.ok((trustedReport.protectedCredentialOverrides.project ?? 0) > 0);
+  assert.ok((trustedReport.protectedCredentialOverrides.dotenv ?? 0) > 0);
+
+  const trustedProfiles = await loadProfiles(project);
+  assert.equal(trustedProfiles.profiles.shared?.baseURL, "https://attacker.invalid/v1?token=secret");
+  assert.equal(trustedProfiles.profiles.shared?.apiKey, "parent-token");
+  assert.equal(trustedProfiles.profiles.shared?.headers?.Authorization, "Bearer parent-token");
+  assert.equal(trustedProfiles.profiles.projectOnly?.protocol, "openai-chat");
+  assert.equal(trustedProfiles.provenance.shared?.baseURL, "project");
+
+  const trustedPermissions = await loadPermissionSettings(project);
+  assert.ok(trustedPermissions.allow.includes("Bash(*)"));
+  assert.equal((await loadSandboxSettings(project)).enabled, false);
+  assert.ok((await loadMcpConfigs(project)).servers.projectServer);
+  assert.ok((await getEnabledPluginState(project)).enabled.has("project@registry"));
+  assert.equal(await settings.readMergedStringSetting(project, "language"), "Project language");
+  const commandEnvironment = await settings.readMergedEnv(project);
+  assert.equal(commandEnvironment.PATH, "project-path");
+  assert.equal(commandEnvironment.ANTHROPIC_AUTH_TOKEN, undefined);
+
+  const redacted = redactSettingValue("models", {
+    prod: {
+      baseURL: "https://user:pass@example.com/v1?token=secret",
+      apiKey: "live-secret",
+      headers: { Authorization: "Bearer live-secret" },
+    },
+  });
+  const rendered = JSON.stringify(redacted);
+  assert.ok(!rendered.includes("live-secret"));
+  assert.ok(!rendered.includes("user:pass"));
+  assert.ok(!rendered.includes("token=secret"));
+  assert.ok(rendered.includes("[redacted]"));
+  assert.ok(!redactUrlForDisplay("https://user:pass@example.com/v1?q=secret").includes("secret"));
+  assert.deepEqual(redactSettingValue("x-api-key", "live-secret"), "[redacted]");
+
+  const modelsOutput = await commandOutput(["get", "models"]);
+  assert.ok(modelsOutput.includes("[redacted]"));
+  assert.ok(modelsOutput.includes("[project]"));
+  assert.ok(!modelsOutput.includes("inline-project-key"));
+  assert.ok(!modelsOutput.includes("token=secret"));
+  const envOutput = await commandOutput(["get", "env"]);
+  assert.ok(envOutput.includes("[redacted]"));
+  assert.ok(!envOutput.includes("project-token"));
+  assert.ok(!envOutput.includes("project-path"));
+
+  const { APIConnectionError } = await import("@anthropic-ai/sdk");
+  const { getUserFacingErrorMessage } = await import("../services/api/errors.js");
+  process.env.ANTHROPIC_BASE_URL = "https://user:pass@example.com/v1?token=secret";
+  const connectionMessage = getUserFacingErrorMessage(
+    new APIConnectionError({ message: "connection failed" }),
+  );
+  assert.ok(connectionMessage.includes("https://example.com/…"));
+  assert.ok(!connectionMessage.includes("user:pass"));
+  assert.ok(!connectionMessage.includes("token=secret"));
+
+  process.stdout.write("Configuration trust boundary passed.\n");
+} finally {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnvironment)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnvironment);
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/src/scripts/test-config-trust-cli.ts
+++ b/src/scripts/test-config-trust-cli.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import type { AddressInfo } from "node:net";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "../..");
+const CLI_PATH = path.join(PROJECT_ROOT, "src", "entrypoint", "cli.ts");
+const TSX_IMPORT = import.meta.resolve("tsx");
+
+interface CapturedRequest {
+  headers: IncomingHttpHeaders;
+  url: string;
+}
+
+interface TestServer {
+  baseURL: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}
+
+function event(type: string, value: unknown): string {
+  return `event: ${type}\ndata: ${JSON.stringify(value)}\n\n`;
+}
+
+function responseStream(): string {
+  return [
+    event("message_start", {
+      type: "message_start",
+      message: {
+        id: "msg_config_trust",
+        type: "message",
+        role: "assistant",
+        model: "fixture-model",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }),
+    event("content_block_start", {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    }),
+    event("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "ok" },
+    }),
+    event("content_block_stop", { type: "content_block_stop", index: 0 }),
+    event("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 1 },
+    }),
+    event("message_stop", { type: "message_stop" }),
+  ].join("");
+}
+
+async function startServer(): Promise<TestServer> {
+  const requests: CapturedRequest[] = [];
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      requests.push({ headers: request.headers, url: request.url ?? "" });
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(responseStream());
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    baseURL: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function runCli(
+  cwd: string,
+  home: string,
+  baseURL: string,
+  extraArgs: string[] = [],
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        TSX_IMPORT,
+        CLI_PATH,
+        "--print",
+        "reply",
+        "--model",
+        "fixture-model",
+        ...extraArgs,
+      ],
+      {
+        cwd,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          ANTHROPIC_AUTH_TOKEN: "parent-token",
+          ANTHROPIC_BASE_URL: baseURL,
+          ANTHROPIC_MODEL: "fixture-model",
+          EASY_AGENT_DISABLE_HOOKS: "1",
+          EASY_AGENT_ENABLE_STREAM_DEBUG: "0",
+          EASY_AGENT_ENABLE_TOOL_SEARCH: "false",
+          NO_COLOR: "1",
+          FORCE_COLOR: "0",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => child.kill("SIGKILL"), 30_000);
+    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
+    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString("utf8")));
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+const root = await fs.mkdtemp(path.join(os.tmpdir(), "easy-agent-config-trust-cli-"));
+const project = path.join(root, "project");
+const home = path.join(root, "home");
+const safe = await startServer();
+const projectEndpoint = await startServer();
+
+try {
+  await Promise.all([fs.mkdir(project, { recursive: true }), fs.mkdir(home, { recursive: true })]);
+  await fs.writeFile(
+    path.join(project, ".env"),
+    `ANTHROPIC_BASE_URL=${projectEndpoint.baseURL}\nANTHROPIC_AUTH_TOKEN=project-token\n`,
+    "utf8",
+  );
+
+  const untrusted = await runCli(project, home, safe.baseURL);
+  assert.equal(untrusted.code, 0, untrusted.stderr);
+  assert.equal(untrusted.stdout, "ok\n");
+  assert.equal(safe.requests.length, 1);
+  assert.equal(projectEndpoint.requests.length, 0);
+  assert.match(untrusted.stderr, /Project configuration ignored/);
+  assert.ok(!untrusted.stderr.includes(projectEndpoint.baseURL));
+  assert.ok(!untrusted.stderr.includes("project-token"));
+
+  const explicitlyTrusted = await runCli(project, home, safe.baseURL, [
+    "--trust-project-config",
+  ]);
+  assert.equal(explicitlyTrusted.code, 0, explicitlyTrusted.stderr);
+  assert.equal(explicitlyTrusted.stdout, "ok\n");
+  assert.equal(safe.requests.length, 1);
+  assert.equal(projectEndpoint.requests.length, 1);
+  assert.equal(projectEndpoint.requests[0]?.headers["x-api-key"], "parent-token");
+  assert.ok(!explicitlyTrusted.stderr.includes("project-token"));
+  await assert.rejects(fs.access(path.join(home, ".easy-agent", "state.json")));
+
+  process.stdout.write("Headless configuration trust boundary passed.\n");
+} finally {
+  await Promise.all([safe.close(), projectEndpoint.close()]);
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/src/scripts/test-mcp.ts
+++ b/src/scripts/test-mcp.ts
@@ -38,6 +38,10 @@ import { getMcpRegistry, getMcpRegistryEntry, clearMcpRegistry } from "../servic
 import { _resetMcpClientForTesting } from "../services/mcp/client.js";
 import { registerMcpTools, findToolByName, getAllTools } from "../tools/index.js";
 import type { ToolContext } from "../tools/Tool.js";
+import {
+  resetGlobalStateCache,
+  trustProjectForSession,
+} from "../config/globalState.js";
 
 const ctx: ToolContext = { cwd: process.cwd() };
 
@@ -54,6 +58,7 @@ async function resetMcpStateForTest(): Promise<string> {
   // Repoint HOME so loadMcpConfigs' user-scope read finds nothing.
   const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "easy-agent-mcp-home-"));
   process.env.HOME = fakeHome;
+  resetGlobalStateCache();
   return fakeHome;
 }
 
@@ -109,6 +114,7 @@ async function testConfigValidation() {
       },
     }),
   );
+  await trustProjectForSession(tmp);
   const result = await loadMcpConfigs(tmp);
   const good = result.servers["good-stdio"];
   if (good && good.type !== "http" && good.type !== "sse" && good.command === "echo") pass("good-stdio validated");
@@ -215,6 +221,7 @@ async function testEndToEnd(): Promise<void> {
       },
     }),
   );
+  await trustProjectForSession(tmpCwd);
 
   const result = await bootstrapMcp(tmpCwd);
   if (result.connections.length === 2) pass(`bootstrap returned ${result.connections.length} connections`);
@@ -299,6 +306,7 @@ async function testNonBlockingBootstrap(): Promise<void> {
       mcpServers: { inline: { command: "node", args: [serverPath] } },
     }),
   );
+  await trustProjectForSession(tmpCwd);
 
   // Don't await — kick off bootstrap in background, exactly like cli.ts does.
   const bootstrapPromise = bootstrapMcp(tmpCwd);
@@ -415,6 +423,7 @@ async function testHttpTransport(): Promise<void> {
       },
     }),
   );
+  await trustProjectForSession(tmpCwd);
 
   const result = await bootstrapMcp(tmpCwd);
   const ok = result.connections.find((c) => c.name === "remote-ok");
@@ -454,6 +463,7 @@ async function testHttpTransport(): Promise<void> {
       },
     }),
   );
+  await trustProjectForSession(tmpCwd);
   const badResult = await bootstrapMcp(tmpCwd);
   const bad = badResult.connections.find((c) => c.name === "remote-bad");
   if (bad?.type === "failed") pass(`401 → connection marked failed (${bad.error.slice(0, 80)}…)`);

--- a/src/scripts/test-queryengine-characterization.ts
+++ b/src/scripts/test-queryengine-characterization.ts
@@ -33,6 +33,10 @@ import {
   getSessionPaths,
 } from "../session/storage.js";
 import { getTaskMode, setTaskMode } from "../state/taskModeStore.js";
+import {
+  resetGlobalStateCache,
+  trustProjectForSession,
+} from "../config/globalState.js";
 
 const GOLDEN_PATH = path.join(
   import.meta.dirname,
@@ -235,11 +239,13 @@ async function buildRecording(): Promise<string> {
   await mkdir(isolatedHome, { recursive: true });
   process.env.HOME = isolatedHome;
   process.env.USERPROFILE = isolatedHome;
+  resetGlobalStateCache();
   registerPathReplacement(tmpRoot, "<TMP>");
   registerPathReplacement(os.tmpdir(), "<TMPDIR>");
 
   const isolatedCwd = path.join(tmpRoot, "project");
   await mkdir(isolatedCwd, { recursive: true });
+  await trustProjectForSession(isolatedCwd);
   registerPathReplacement(isolatedCwd, "<CWD>");
 
   async function section(label: string, fn: () => Promise<string[]>): Promise<void> {
@@ -431,6 +437,7 @@ async function buildRecording(): Promise<string> {
   // config --------------------------------------------------------------------
   await section("config", async () => {
     const cfgCwd = await mkdtemp(path.join(tmpRoot, "cfg-"));
+    await trustProjectForSession(cfgCwd);
     registerPathReplacement(cfgCwd, "<CFGCWD>");
     const e = makeEngine(cfgCwd);
     return [

--- a/src/scripts/test-stage23.ts
+++ b/src/scripts/test-stage23.ts
@@ -52,6 +52,7 @@ import {
 } from "../commands/userCommands/registry.js";
 import { bootstrapUserCommands } from "../commands/userCommands/bootstrap.js";
 import { updateUserSettings, readMergedStringSetting } from "../utils/settings.js";
+import { trustProjectForSession } from "../config/globalState.js";
 
 // ─── Test plumbing ──────────────────────────────────────────────────
 
@@ -402,6 +403,7 @@ async function main(): Promise<void> {
       path.join(cwd, ".easy-agent", "settings.json"),
       JSON.stringify({ outputStyle: "Learning" }, null, 2),
     );
+    await trustProjectForSession(cwd);
     const mergedProj = await readMergedStringSetting(cwd, "outputStyle");
     assert(mergedProj === "Learning", "project outputStyle overrides user outputStyle");
   });

--- a/src/scripts/test-stage35.ts
+++ b/src/scripts/test-stage35.ts
@@ -587,12 +587,13 @@ async function main(): Promise<void> {
   );
   resetGlobalStateCache();
   res = await runtime.refreshActivePlugins(projectCwd, { applyMcp: false });
-  assert(res.plugins.length === 1, "project-enabled plugin still loads its prompt components");
+  assert(res.plugins.length === 0, "UNTRUSTED: project-enabled plugin is not activated");
   assert(Object.keys(runtime.getActivePluginHooks()).length === 0, "UNTRUSTED: plugin hooks NOT applied");
 
   await trustProject(projectCwd);
   resetGlobalStateCache();
   res = await runtime.refreshActivePlugins(projectCwd, { applyMcp: false });
+  assert(res.plugins.length === 1, "TRUSTED: project-enabled plugin is activated");
   assert((runtime.getActivePluginHooks().PreToolUse?.length ?? 0) === 1, "TRUSTED: plugin hooks applied");
 
   // [8b] deterministic manifest-name conflict

--- a/src/scripts/test-streaming.ts
+++ b/src/scripts/test-streaming.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 import { loadEnv } from "../utils/loadEnv.js";
-loadEnv();
+await loadEnv(process.cwd(), { allowProject: true });
 /**
  * Phase 1 verification script — Test LLM API streaming communication.
  *

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -19,6 +19,7 @@ import {
   APIConnectionTimeoutError,
   APIError,
 } from "@anthropic-ai/sdk";
+import { redactUrlForDisplay } from "../../config/redaction.js";
 
 // ─── Categories ────────────────────────────────────────────────────
 
@@ -237,7 +238,7 @@ export function getUserFacingErrorMessage(
     case "model_not_found":
       return `${API_ERROR_MESSAGE_PREFIX}: The model${model ? ` "${model}"` : ""} was not found or is not accessible. Use /model to pick a different one.`;
     case "connection_error":
-      return `${API_ERROR_MESSAGE_PREFIX}: Could not reach the API (network error). Check your connection${process.env.ANTHROPIC_BASE_URL ? ` and ANTHROPIC_BASE_URL (${process.env.ANTHROPIC_BASE_URL})` : ""}.`;
+      return `${API_ERROR_MESSAGE_PREFIX}: Could not reach the API (network error). Check your connection${process.env.ANTHROPIC_BASE_URL ? ` and ANTHROPIC_BASE_URL (${redactUrlForDisplay(process.env.ANTHROPIC_BASE_URL)})` : ""}.`;
     case "aborted":
       return rawMessage;
     default:

--- a/src/services/api/providers/profile.ts
+++ b/src/services/api/providers/profile.ts
@@ -24,16 +24,16 @@
  * stack never learns a profile is non-Anthropic — it keeps speaking the
  * normalized StreamEvent contract.
  *
- * Security: `apiKey` is privilege-sensitive. An inline literal key declared in a
- * project/local settings file (which a hostile repo could commit) is IGNORED;
- * only `${ENV}` interpolation, or a key from a trusted scope (user/policy), is
- * honored. This mirrors how `mode: auto` is gated in the settings layer.
+ * Provider selection, endpoints, credentials, and headers from project/local
+ * settings are ignored until workspace trust has been established.
  */
 
 import {
   loadSettingSources,
   isTrustedScopeForSensitiveKeys,
+  type SettingSource,
 } from "../../../config/sources.js";
+import { isProjectTrusted } from "../../../config/globalState.js";
 
 export type ModelProtocol =
   | "anthropic"
@@ -78,16 +78,14 @@ function interpolateEnv(value: string): string {
   return value.replace(/\$\{([A-Z0-9_]+)\}/gi, (_, name) => process.env[name] ?? "");
 }
 
-/** True when the string references at least one `${ENV}` placeholder. */
-function usesEnvInterpolation(value: string): boolean {
-  return /\$\{[A-Z0-9_]+\}/i.test(value);
-}
-
 export interface LoadedProfiles {
   profiles: Record<string, ModelProfile>;
   defaultModel?: string;
   /** Non-fatal notices (dropped inline secrets, malformed entries). */
   warnings: string[];
+  /** Effective source for each merged profile field. Contains no values. */
+  provenance: Record<string, Partial<Record<keyof RawProfile, SettingSource>>>;
+  defaultModelSource?: SettingSource;
 }
 
 /**
@@ -97,12 +95,15 @@ export interface LoadedProfiles {
 export async function loadProfiles(cwd: string = process.cwd()): Promise<LoadedProfiles> {
   const sources = await loadSettingSources(cwd);
   const merged: Record<string, RawProfile> = {};
+  const provenance: LoadedProfiles["provenance"] = {};
   const warnings: string[] = [];
   let defaultModel: string | undefined;
+  let defaultModelSource: SettingSource | undefined;
+  const workspaceTrusted = await isProjectTrusted(cwd);
 
   for (const src of sources) {
     if (!src.raw) continue;
-    const trusted = isTrustedScopeForSensitiveKeys(src.source);
+    const trusted = isTrustedScopeForSensitiveKeys(src.source) || workspaceTrusted;
 
     const models = src.raw.models;
     if (models && typeof models === "object" && !Array.isArray(models)) {
@@ -110,26 +111,26 @@ export async function loadProfiles(cwd: string = process.cwd()): Promise<LoadedP
         if (!value || typeof value !== "object" || Array.isArray(value)) continue;
         const raw: RawProfile = { ...(value as RawProfile) };
 
-        // Drop inline literal API keys from project/local scopes — only
-        // ${ENV} interpolation (or a trusted scope) may supply credentials.
-        if (
-          !trusted &&
-          typeof raw.apiKey === "string" &&
-          raw.apiKey.trim().length > 0 &&
-          !usesEnvInterpolation(raw.apiKey)
-        ) {
+        if (!trusted) {
           warnings.push(
-            `models.${id}.apiKey: inline secret from "${src.source}" scope ignored — use \${ENV} or a user/policy settings file`,
+            `models.${id}: profile from "${src.source}" scope ignored until the workspace is trusted`,
           );
-          delete raw.apiKey;
+          continue;
         }
 
         merged[id] = { ...merged[id], ...raw };
+        const fieldSources = (provenance[id] ??= {});
+        for (const key of Object.keys(raw) as (keyof RawProfile)[]) {
+          fieldSources[key] = src.source;
+        }
       }
     }
 
     const dm = src.raw.defaultModel;
-    if (typeof dm === "string" && dm.trim().length > 0) defaultModel = dm.trim();
+    if (trusted && typeof dm === "string" && dm.trim().length > 0) {
+      defaultModel = dm.trim();
+      defaultModelSource = src.source;
+    }
   }
 
   const profiles: Record<string, ModelProfile> = {};
@@ -138,7 +139,13 @@ export async function loadProfiles(cwd: string = process.cwd()): Promise<LoadedP
     if (built) profiles[id] = built;
   }
 
-  return { profiles, defaultModel, warnings };
+  return {
+    profiles,
+    defaultModel,
+    warnings,
+    provenance,
+    ...(defaultModelSource ? { defaultModelSource } : {}),
+  };
 }
 
 function buildProfile(

--- a/src/services/mcp/config.ts
+++ b/src/services/mcp/config.ts
@@ -22,7 +22,11 @@ import type {
 } from "../../types/mcp.js";
 import * as path from "node:path";
 import { logWarn } from "../../utils/log.js";
-import { loadSettingSources, type SettingSource } from "../../config/sources.js";
+import {
+  loadSettingSources,
+  loadTrustedSettingSources,
+  type SettingSource,
+} from "../../config/sources.js";
 import { isProjectTrusted } from "../../config/globalState.js";
 import { readJsonSettingsFile } from "../../utils/settings.js";
 
@@ -225,7 +229,10 @@ async function loadProjectMcpJson(
  * so a single malformed entry can't take the whole CLI down).
  */
 export async function loadMcpConfigs(cwd: string): Promise<McpConfigLoadResult> {
-  const sources = await loadSettingSources(cwd);
+  const [allSources, sources] = await Promise.all([
+    loadSettingSources(cwd),
+    loadTrustedSettingSources(cwd),
+  ]);
 
   const errors: string[] = [];
   const servers: Record<string, ScopedMcpServerConfig> = {};
@@ -238,6 +245,10 @@ export async function loadMcpConfigs(cwd: string): Promise<McpConfigLoadResult> 
     if (!src.raw) continue;
     if (src.raw["enableAllProjectMcpServers"] === true) enableAll = true;
     enabled.push(...asStringArray(src.raw["enabledMcpjsonServers"]));
+    disabled.push(...asStringArray(src.raw["disabledMcpjsonServers"]));
+  }
+  for (const src of allSources) {
+    if (!src.raw) continue;
     disabled.push(...asStringArray(src.raw["disabledMcpjsonServers"]));
   }
 

--- a/src/ui/components/TrustDialog.tsx
+++ b/src/ui/components/TrustDialog.tsx
@@ -2,11 +2,10 @@
  * First-run trust prompt.
  *
  * Shown the first time the agent is started in a directory the user hasn't
- * trusted yet. Project-scoped settings can configure hooks, statusLine
- * commands, MCP servers and Bash allow-rules — all of which can execute code —
- * so we ask for explicit consent before honoring any of them. Declining exits
- * the CLI; trusting persists the decision (in the machine-level State store,
- * never inside the project) and continues.
+ * trusted yet. Project-scoped settings can change provider routing,
+ * environment variables, filesystem access, and command execution. Declining
+ * exits the CLI; trusting persists the decision in machine-level state and
+ * continues.
  */
 
 import React from "react";
@@ -67,9 +66,9 @@ export function TrustDialog({ cwd, risks, onDecision }: TrustDialogProps): React
       </Box>
       <Box marginTop={1}>
         <Text>
-          This folder may contain project settings (hooks, status line, MCP
-          servers, Bash rules) that can run commands on your machine. Only
-          continue if you trust its source.
+          This folder may contain settings that change environment variables,
+          provider endpoints, credentials, filesystem access, or commands on
+          your machine. Only continue if you trust its source.
         </Text>
       </Box>
       {risks.length > 0 ? (

--- a/src/ui/trustGate.tsx
+++ b/src/ui/trustGate.tsx
@@ -5,11 +5,12 @@
  * standalone Ink root and waits for the user's decision. Trusting persists the
  * decision and continues; declining returns false so the entrypoint can exit.
  *
- * Non-interactive invocations (no TTY) never prompt — they simply run
- * untrusted, which means project/local hooks and statusLine commands are not
- * executed (enforced in their loaders via the trusted source set).
+ * Non-interactive trust policy is resolved by the CLI before project settings
+ * are applied or execution-capable extensions are initialized.
  */
 
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { isProjectTrusted, trustProject } from "../config/globalState.js";
 import { loadSettingSources } from "../config/sources.js";
 
@@ -21,6 +22,30 @@ export async function detectRisks(cwd: string): Promise<string[]> {
     if (src.source !== "project" && src.source !== "local") continue;
     const raw = src.raw;
     if (!raw) continue;
+    if (
+      raw["env"] &&
+      typeof raw["env"] === "object" &&
+      Object.keys(raw["env"] as Record<string, unknown>).length > 0
+    ) {
+      risks.add("environment variables");
+    }
+    if (
+      raw["models"] &&
+      typeof raw["models"] === "object" &&
+      Object.values(raw["models"] as Record<string, unknown>).some((profile) => {
+        if (!profile || typeof profile !== "object" || Array.isArray(profile)) return false;
+        const value = profile as Record<string, unknown>;
+        return ["protocol", "baseURL", "apiKey", "headers"].some(
+          (key) => value[key] !== undefined,
+        );
+      })
+    ) {
+      risks.add("model provider endpoints or credentials");
+    }
+    if (raw["apiKeyHelper"]) risks.add("an API key helper command");
+    if (Array.isArray(raw["additionalDirectories"]) && raw["additionalDirectories"].length > 0) {
+      risks.add("additional filesystem roots");
+    }
     if (raw["hooks"] && typeof raw["hooks"] === "object") risks.add("lifecycle hooks (run shell commands)");
     if (raw["statusLine"]) risks.add("a custom status line command");
     if (raw["mcpServers"] && typeof raw["mcpServers"] === "object") risks.add("MCP servers");
@@ -33,11 +58,16 @@ export async function detectRisks(cwd: string): Promise<string[]> {
     ) {
       risks.add("project plugins (may include hooks or MCP servers)");
     }
-    if (raw["mode"] === "auto") risks.add('permission mode "auto" (ignored until trusted)');
     const allow = raw["allow"];
     if (Array.isArray(allow) && allow.some((r) => typeof r === "string" && r.startsWith("Bash("))) {
       risks.add("Bash allow-rules");
     }
+  }
+  try {
+    await fs.access(path.join(cwd, ".env"));
+    risks.add("a project .env file");
+  } catch {
+    // Missing or unreadable files add no trust-dialog risk item.
   }
   return [...risks];
 }

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -1,65 +1,108 @@
 /**
- * loadEnv — Multi-source environment variable loader.
- *
- * Loads env vars from the Easy Agent settings chain plus a project-local
- * dotenv file, with increasing priority (later sources override earlier ones):
- *
- *   1. ~/.easy-agent/settings.json            → user-scope `env` block
- *   2. <cwd>/.easy-agent/settings.json        → project-scope `env` block
- *   3. <cwd>/.easy-agent/settings.local.json  → project-local `env` block
- *   4. .env (cwd)                             → dotenv file (highest priority)
- *
- * The settings `env` blocks let users keep model API keys (and any other
- * variable referenced via `${VAR}` in a model profile) alongside the rest of
- * their configuration. A repo-local `.env` still wins so a developer can
- * override committed defaults without editing settings.json.
- *
- * Note: the project/local `env` blocks come from repo files. This is the same
- * trust posture as the cwd `.env` file (which dotenv already auto-loads), so it
- * introduces no attack surface beyond what `.env` provides.
+ * Applies settings-backed environment variables after workspace trust has
+ * been resolved. User, explicit flag, and managed policy sources are always
+ * eligible. Project settings, local settings, and `<cwd>/.env` are applied
+ * only for a trusted workspace.
  */
 
-import * as fs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import dotenv from "dotenv";
+import { isProjectTrusted } from "../config/globalState.js";
+import { loadSettingSources } from "../config/sources.js";
 import {
-  getUserSettingsPath,
-  getProjectSettingsPath,
-  getLocalSettingsPath,
-} from "./paths.js";
+  captureInheritedEnvironment,
+  isInheritedCredentialProtected,
+  setEnvironmentLoadReport,
+  type EnvironmentConfigSource,
+  type EnvironmentLoadReport,
+} from "../config/environment.js";
 
-function readJsonEnv(filePath: string): Record<string, string> {
-  try {
-    const raw = fs.readFileSync(filePath, "utf-8");
-    const parsed: unknown = JSON.parse(raw);
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      "env" in parsed &&
-      (parsed as { env?: unknown }).env &&
-      typeof (parsed as { env?: unknown }).env === "object"
-    ) {
-      const out: Record<string, string> = {};
-      for (const [k, v] of Object.entries((parsed as { env: Record<string, unknown> }).env)) {
-        if (typeof v === "string") out[k] = v;
-      }
-      return out;
-    }
-  } catch {
-    // File doesn't exist or is invalid JSON — silently skip.
-  }
-  return {};
+export interface LoadEnvironmentOptions {
+  /** Explicit caller authorization for project settings and `.env`. */
+  allowProject?: boolean;
 }
 
-export function loadEnv(): void {
-  const cwd = process.cwd();
+function readSourceEnv(raw: Record<string, unknown> | null): Record<string, string> {
+  const value = raw?.env;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    if (item === undefined || item === null) continue;
+    out[key] = typeof item === "string" ? item : String(item);
+  }
+  return out;
+}
 
-  // Settings `env` blocks, low → high priority (later wins).
-  Object.assign(process.env, readJsonEnv(getUserSettingsPath()));
-  Object.assign(process.env, readJsonEnv(getProjectSettingsPath(cwd)));
-  Object.assign(process.env, readJsonEnv(getLocalSettingsPath(cwd)));
+async function readDotenv(cwd: string): Promise<Record<string, string>> {
+  try {
+    return dotenv.parse(await fs.readFile(path.join(cwd, ".env")));
+  } catch {
+    return {};
+  }
+}
 
-  // .env file (highest priority — project-local overrides everything).
-  // `quiet` suppresses dotenv's "injected env (N) from .env" tip banner so
-  // the REPL opens on a clean welcome card instead of a stray log line.
-  dotenv.config({ override: true, quiet: true });
+async function hasDotenv(cwd: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(cwd, ".env"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function increment(
+  counts: Partial<Record<EnvironmentConfigSource, number>>,
+  source: EnvironmentConfigSource,
+): void {
+  counts[source] = (counts[source] ?? 0) + 1;
+}
+
+export async function loadEnv(
+  cwd: string = process.cwd(),
+  options: LoadEnvironmentOptions = {},
+): Promise<EnvironmentLoadReport> {
+  captureInheritedEnvironment();
+  const projectTrusted = options.allowProject === true || (await isProjectTrusted(cwd));
+  const sources = await loadSettingSources(cwd);
+  const report: EnvironmentLoadReport = {
+    projectTrusted,
+    effectiveSources: {},
+    ignoredBySource: {},
+    protectedCredentialOverrides: {},
+  };
+
+  const apply = (
+    source: EnvironmentConfigSource,
+    values: Record<string, string>,
+    projectScoped: boolean,
+  ): void => {
+    for (const [key, value] of Object.entries(values)) {
+      if (projectScoped && !projectTrusted) {
+        increment(report.ignoredBySource, source);
+        continue;
+      }
+      if (projectScoped && isInheritedCredentialProtected(key)) {
+        increment(report.protectedCredentialOverrides, source);
+        continue;
+      }
+      process.env[key] = value;
+      report.effectiveSources[key] = source;
+    }
+  };
+
+  for (const source of sources) {
+    if (source.source === "flag") {
+      if (projectTrusted) {
+        apply("dotenv", await readDotenv(cwd), true);
+      } else if (await hasDotenv(cwd)) {
+        increment(report.ignoredBySource, "dotenv");
+      }
+    }
+    const projectScoped = source.source === "project" || source.source === "local";
+    apply(source.source, readSourceEnv(source.raw), projectScoped);
+  }
+
+  setEnvironmentLoadReport(report);
+  return report;
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -40,6 +40,7 @@ import {
   loadTrustedSettingSources,
   resetSettingsCache,
 } from "../config/sources.js";
+import { isInheritedCredentialProtected } from "../config/environment.js";
 
 export interface SettingsFileResult<T = unknown> {
   /** Parsed JSON object, or null if missing / unreadable / invalid. */
@@ -229,16 +230,14 @@ export async function readStatusLineConfig(
 }
 
 /**
- * Read a single top-level string setting, merging user + project scopes
- * with PROJECT winning (project overrides user — same precedence as the
- * MCP / permissions loaders). Returns undefined when the key is absent or
- * not a string in both scopes.
+ * Read a top-level string setting from effective trusted sources. Project and
+ * local values participate only after workspace trust; later sources win.
  */
 export async function readMergedStringSetting(
   cwd: string,
   key: string,
 ): Promise<string | undefined> {
-  const sources = await loadSettingSources(cwd);
+  const sources = await loadTrustedSettingSources(cwd);
   let result: string | undefined;
   for (const src of sources) {
     const value = src.raw?.[key];
@@ -248,15 +247,14 @@ export async function readMergedStringSetting(
 }
 
 /**
- * Read a single top-level numeric setting, merging all sources with the later
- * source winning. Returns undefined when absent / non-numeric everywhere.
- * Used by `cleanupPeriodDays`.
+ * Read a top-level numeric setting from effective trusted sources. Later
+ * sources win. Returns undefined when no eligible source contains a number.
  */
 export async function readMergedNumberSetting(
   cwd: string,
   key: string,
 ): Promise<number | undefined> {
-  const sources = await loadSettingSources(cwd);
+  const sources = await loadTrustedSettingSources(cwd);
   let result: number | undefined;
   for (const src of sources) {
     const value = src.raw?.[key];
@@ -266,16 +264,14 @@ export async function readMergedNumberSetting(
 }
 
 /**
- * Read a single top-level boolean setting, merging all sources with the later
- * source winning. Returns undefined when absent / non-boolean everywhere, so
- * callers can apply their own default. Used by `respectGitignore`,
- * `syntaxHighlightingDisabled`, `prefersReducedMotion`.
+ * Read a top-level boolean setting from effective trusted sources. Later
+ * sources win; callers apply their own default when the key is absent.
  */
 export async function readMergedBooleanSetting(
   cwd: string,
   key: string,
 ): Promise<boolean | undefined> {
-  const sources = await loadSettingSources(cwd);
+  const sources = await loadTrustedSettingSources(cwd);
   let result: boolean | undefined;
   for (const src of sources) {
     const value = src.raw?.[key];
@@ -327,6 +323,12 @@ export async function readMergedEnv(cwd: string): Promise<Record<string, string>
     if (!env || typeof env !== "object" || Array.isArray(env)) continue;
     for (const [key, value] of Object.entries(env as Record<string, unknown>)) {
       if (value === undefined || value === null) continue;
+      if (
+        (src.source === "project" || src.source === "local") &&
+        isInheritedCredentialProtected(key)
+      ) {
+        continue;
+      }
       out[key] = typeof value === "string" ? value : String(value);
     }
   }

--- a/src/utils/toolSearch.ts
+++ b/src/utils/toolSearch.ts
@@ -23,6 +23,7 @@
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import { toolToApiParam, type ApiToolParam, type Tool } from "../tools/Tool.js";
 import type { ContentBlock, ToolReferenceBlock } from "../types/message.js";
+import { redactUrlForDisplay } from "../config/redaction.js";
 import { debugLog } from "./log.js";
 import { getContextWindowForModel } from "./tokens.js";
 import { areExperimentalBetasDisabled } from "./experimentalBetas.js";
@@ -285,7 +286,9 @@ export function isToolSearchEnabled(
     !getToolSearchEnvValue() &&
     !isFirstPartyAnthropicBaseUrl(env.baseURL)
   ) {
-    log(false, "non_first_party_base_url", { baseURL: env.baseURL });
+    log(false, "non_first_party_base_url", {
+      baseURL: env.baseURL ? redactUrlForDisplay(env.baseURL) : undefined,
+    });
     return false;
   }
 


### PR DESCRIPTION
## Problem

An untrusted checkout could apply project/local `env`, `.env`, provider profiles, MCP/plugin/sandbox settings before trust. In headless mode this could redirect an inherited API token to a project-controlled endpoint.

## Result

- resolve workspace trust before environment and provider setup
- ignore trust-sensitive project/local settings and `.env` while untrusted
- add one-run `--trust-project-config` for reviewed headless jobs
- keep parent credentials authoritative over project/local/.env credential variables
- report effective sources with credential and URL redaction
- retain trusted-project behavior and restrictive untrusted settings
- document precedence and migration

Closes #5

## Validation

- `npm run test:config-trust` — passed
- `npm run verify:production` — 53 passed, 0 skipped, 0 failed
- `npm run verify:production:platform` — 2 passed
- `npm pack --dry-run --cache /tmp/easy-agent-issue5-npm-cache` — passed
- `node dist/eagent.js --help` — passed
- `node dist/eagent.js --version` — passed

## Manual security scenarios

- An untrusted headless project with a malicious `.env` kept the parent endpoint and token; the project endpoint received no request.
- Explicit `--trust-project-config` routed to the reviewed project endpoint for that process only; the parent token still won over the project token, and no trust state was persisted.
- `/config`, `/model list`, `/doctor`, API connection errors, and ToolSearch debug logs did not expose secrets or URL credentials/query values.

## Compatibility

Interactive trusted workspaces retain project configuration. Existing headless/CI jobs relying on new or untrusted project configuration must move settings to user/parent sources, establish persistent trust, or add `--trust-project-config`. Project/local `mode` and `autoMode` remain forbidden. Restrictive deny/disable settings continue to apply while untrusted.

## Remaining risk

Trusting a project authorizes its provider endpoints and `${ENV}` interpolation; users must review provider profiles before granting trust.
